### PR TITLE
Host Build on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ else()
 endif()
 ```
 
+### Building on MacOS
+Currently only GCC is supported. You can install GCC via homebrew and then pass flags to CMake to use that compiler:
+
+```shell
+brew install gcc
+mkdir cmake-macos
+cd cmake-macos
+cmake -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 ..
+make
+```
+
+
 Here's an example of how your `main.cpp` could look like if you want to compile for both ESP and Linux. The example
  assumes you have named your main class `App`  and it is derived from `smooth::core::Application`, which most
   applications based on Smooth do. Doing so is not mandatory, it saves you some setup; see

--- a/README.md
+++ b/README.md
@@ -145,9 +145,24 @@ Please see the the different test projects under the test folder. When compiling
 root of the repo as a CMake project. Select the project you wish to build by setting `selected_test_project` 
 in the top `CMakeLists.txt`. **You will likely have to re-generate your build files after changing the selection.**  
 
-## Using Smooth in your project (compiling for Linux)
+## Using Smooth in your project (compiling for Linux or MacOS)
 
-To build you application for Linux you must maintain a parallel build configuration as follows:
+### System Libraries
+Some libraries provided in the ESP distribution need to be installed as system libraries on the host. On Debian / Ubuntu:
+
+```shell
+apt-get install libsodium-dev libmbedtls-dev
+```
+
+With Homebrew on MacOS:
+
+```shell
+brew install libsodium mbedtls
+```
+
+
+### CMake Config
+To build your application on the host platform you must maintain a parallel build configuration as follows:
 
 Top `CMakeList.txt`
 
@@ -160,6 +175,10 @@ if(${ESP_PLATFORM})
              externals/smooth/smooth_component)
     project(your_project_name)
 else()
+    # first two entries are needed only on MacOS - brew installs libraries into /usr/local
+    include_directories(SYSTEM /usr/local/include)
+    link_directories(/usr/local/lib)
+
     add_subdirectory(main)
     add_subdirectory(externals/smooth/lib)
     add_subdirectory(externals/smooth/mock-idf)

--- a/lib/smooth/core/network/SocketDispatcher.cpp
+++ b/lib/smooth/core/network/SocketDispatcher.cpp
@@ -361,12 +361,12 @@ namespace smooth::core::network
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 
-    void SocketDispatcher::set_fd(std::size_t socket_id, fd_set& fd)
+    void SocketDispatcher::set_fd(FD socket_id, fd_set& fd)
     {
         FD_SET(socket_id, &fd);
     }
 
-    bool SocketDispatcher::is_fd_set(std::size_t socket_id, fd_set& fd)
+    bool SocketDispatcher::is_fd_set(FD socket_id, fd_set& fd)
     {
         return FD_ISSET(socket_id, &fd);
     }

--- a/lib/smooth/include/smooth/core/network/ISocket.h
+++ b/lib/smooth/include/smooth/core/network/ISocket.h
@@ -33,7 +33,7 @@ namespace smooth::core::network
         friend class smooth::core::network::SocketDispatcher;
         public:
             static const int INVALID_SOCKET = -1;
-#ifdef ESP_PLATFORM
+#if defined(ESP_PLATFORM) || defined(__APPLE__)
 
             // lwip doesn't signal SIGPIPE
             static const int SEND_FLAGS = 0;

--- a/lib/smooth/include/smooth/core/network/SocketDispatcher.h
+++ b/lib/smooth/include/smooth/core/network/SocketDispatcher.h
@@ -43,6 +43,11 @@ namespace smooth::core::network
         private ISocketBackOff
     {
         public:
+#ifdef ESP_PLATFORM
+            typedef size_t FD;
+#else
+            typedef int FD;
+#endif
             ~SocketDispatcher() override = default;
 
             static SocketDispatcher& instance();
@@ -90,9 +95,9 @@ namespace smooth::core::network
             using SocketOperationQueue = smooth::core::ipc::TaskEventQueue<SocketOperation>;
             std::shared_ptr<SocketOperationQueue> socket_op;
 
-            static void set_fd(std::size_t socket_id, fd_set& fd);
+            static void set_fd(FD socket_id, fd_set& fd);
 
-            static bool is_fd_set(std::size_t socket_id, fd_set& fd);
+            static bool is_fd_set(FD socket_id, fd_set& fd);
 
             void print_status() const;
 

--- a/lib/smooth/include/smooth/core/network/util.h
+++ b/lib/smooth/include/smooth/core/network/util.h
@@ -17,7 +17,7 @@ limitations under the License.
 
 #pragma once
 
-#ifdef ESP_PLATFORM
+#if defined(ESP_PLATFORM) || defined(__APPLE__)
     #include <machine/endian.h>
     #if _BYTE_ORDER == _LITTLE_ENDIAN
         #define SMOOTH_LITTLE_ENDIAN


### PR DESCRIPTION
These were the changes I needed to build on MacOS with GCC.

[Posix defines](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/select.h.html) FD_SET fd argument as `int`. `size_t` seems to be an ESP thing. Linux compiles either way without warnings, but there is a conversion error (due to -Wconversion) on MacOS. 