### PR TITLE
bugfix and additional functionality for Wifi.cpp 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ Below is the list of indiviuals that have contributed to the project.
 |----|----|
 |[Per Malmberg](https://github.com/PerMalmberg)|Author and maintainer|
 |[squonk11](https://github.com/squonk11)|[PR#65](https://github.com/PerMalmberg/Smooth/pull/65)|
+|[squonk11](https://github.com/squonk11)|[PR#114](https://github.com/PerMalmberg/Smooth/pull/114)|
 |[KerryRJ](https://github.com/KerryRJ)|[PR#71](https://github.com/PerMalmberg/Smooth/pull/71)|
 |[jeremyjh](https://github.com/jeremyjh)|[PR#87](https://github.com/PerMalmberg/Smooth/pull/87)|
 |[COM8](https://github.com/COM8)|[PR#98](https://github.com/PerMalmberg/Smooth/pull/98)|

--- a/lib/smooth/core/network/Wifi.cpp
+++ b/lib/smooth/core/network/Wifi.cpp
@@ -37,11 +37,10 @@ using namespace smooth::core;
 
 namespace smooth::core::network
 {
-    ip4_addr_t Wifi::ip = { 0 };
+    ip4_addr_t Wifi::ip = {0};
 
     Wifi::Wifi()
     {
-        this->ip.addr = 0;
         tcpip_adapter_init();
         esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &Wifi::wifi_event_callback, this);
         esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, &Wifi::wifi_event_callback, this);
@@ -249,7 +248,7 @@ namespace smooth::core::network
         return err == ESP_OK;
     }
 
-    // attention: access to this function might have a threading issue.
+    // attention: access to this function might have a threading issue. 
     // It should be called from the main thread only!
     ip4_addr_t Wifi::get_local_ip()
     {
@@ -289,4 +288,5 @@ namespace smooth::core::network
                                       ip_changed);
         core::ipc::Publisher<network::NetworkStatus>::publish(status);
     }
+
 }

--- a/lib/smooth/core/network/Wifi.cpp
+++ b/lib/smooth/core/network/Wifi.cpp
@@ -37,6 +37,8 @@ using namespace smooth::core;
 
 namespace smooth::core::network
 {
+    ip4_addr_t Wifi::ip = {0};
+
     Wifi::Wifi()
     {
         this->ip.addr = 0;
@@ -195,7 +197,7 @@ namespace smooth::core::network
         }
     }
 
-    std::string Wifi::get_mac_address() const
+    std::string Wifi::get_mac_address()
     {
         std::stringstream mac;
 
@@ -247,6 +249,8 @@ namespace smooth::core::network
         return err == ESP_OK;
     }
 
+    // attention: access to this function might have a threading issue. 
+    // It should be called from the main thread only!
     ip4_addr_t Wifi::get_local_ip()
     {
         return ip;
@@ -286,5 +290,4 @@ namespace smooth::core::network
         core::ipc::Publisher<network::NetworkStatus>::publish(status);
     }
 
-    ip4_addr_t Wifi::ip;
 }

--- a/lib/smooth/core/network/Wifi.cpp
+++ b/lib/smooth/core/network/Wifi.cpp
@@ -37,7 +37,7 @@ using namespace smooth::core;
 
 namespace smooth::core::network
 {
-    ip4_addr_t Wifi::ip = {0};
+    ip4_addr_t Wifi::ip = { 0 };
 
     Wifi::Wifi()
     {
@@ -248,7 +248,7 @@ namespace smooth::core::network
         return err == ESP_OK;
     }
 
-    // attention: access to this function might have a threading issue. 
+    // attention: access to this function might have a threading issue.
     // It should be called from the main thread only!
     ip4_addr_t Wifi::get_local_ip()
     {
@@ -288,5 +288,4 @@ namespace smooth::core::network
                                       ip_changed);
         core::ipc::Publisher<network::NetworkStatus>::publish(status);
     }
-
 }

--- a/lib/smooth/core/network/Wifi.cpp
+++ b/lib/smooth/core/network/Wifi.cpp
@@ -37,7 +37,7 @@ using namespace smooth::core;
 
 namespace smooth::core::network
 {
-    ip4_addr_t Wifi::ip = {0};
+    ip4_addr_t Wifi::ip = { 0 };
 
     Wifi::Wifi()
     {
@@ -249,7 +249,7 @@ namespace smooth::core::network
         return err == ESP_OK;
     }
 
-    // attention: access to this function might have a threading issue. 
+    // attention: access to this function might have a threading issue.
     // It should be called from the main thread only!
     ip4_addr_t Wifi::get_local_ip()
     {
@@ -289,5 +289,4 @@ namespace smooth::core::network
                                       ip_changed);
         core::ipc::Publisher<network::NetworkStatus>::publish(status);
     }
-
 }

--- a/lib/smooth/include/smooth/core/network/Wifi.h
+++ b/lib/smooth/include/smooth/core/network/Wifi.h
@@ -72,7 +72,7 @@ namespace smooth::core::network
                                             int32_t event_id,
                                             void* event_data);
 
-            [[nodiscard]] std::string get_mac_address() const;
+            [[nodiscard]] static std::string get_mac_address();
 
             [[nodiscard]] static bool get_local_mac_address(std::array<uint8_t, 6>& m);
 

--- a/lib/smooth/include/smooth/core/network/Wifi.h
+++ b/lib/smooth/include/smooth/core/network/Wifi.h
@@ -73,6 +73,8 @@ namespace smooth::core::network
                                             void* event_data);
 
             [[nodiscard]] std::string get_mac_address() const;
+            esp_err_t get_local_mac_address(uint8_t m[6]) const;
+            ip4_addr_t get_local_ip() const;
 
             /// Start providing an access point
             /// \param max_conn maximum number of clients to connect to this AP
@@ -89,5 +91,6 @@ namespace smooth::core::network
             std::string ssid{};
 
             std::string password{};
+            ip4_addr_t ip;
     };
 }

--- a/lib/smooth/include/smooth/core/network/Wifi.h
+++ b/lib/smooth/include/smooth/core/network/Wifi.h
@@ -73,8 +73,10 @@ namespace smooth::core::network
                                             void* event_data);
 
             [[nodiscard]] std::string get_mac_address() const;
-            esp_err_t get_local_mac_address(uint8_t m[6]) const;
-            ip4_addr_t get_local_ip() const;
+
+            [[nodiscard]] static bool get_local_mac_address(std::array<uint8_t, 6>& m);
+
+            [[nodiscard]] static ip4_addr_t get_local_ip();
 
             /// Start providing an access point
             /// \param max_conn maximum number of clients to connect to this AP
@@ -91,6 +93,6 @@ namespace smooth::core::network
             std::string ssid{};
 
             std::string password{};
-            ip4_addr_t ip;
+            static ip4_addr_t ip;
     };
 }

--- a/mock-idf/components/esp_common/esp_err.cpp
+++ b/mock-idf/components/esp_common/esp_err.cpp
@@ -1,1 +1,6 @@
 #include <esp_err.h>
+
+const char *esp_err_to_name(esp_err_t code)
+{
+    return nullptr;
+}

--- a/mock-idf/components/esp_common/include/esp_err.h
+++ b/mock-idf/components/esp_common/include/esp_err.h
@@ -25,3 +25,5 @@ typedef int32_t esp_err_t;
 #define ESP_ERR_FLASH_BASE          0x6000  /*!< Starting number of flash error codes */
 
 #define ESP_ERROR_CHECK(x) (x)
+
+const char *esp_err_to_name(esp_err_t code);

--- a/mock-idf/components/esp_wifi/esp_wifi.cpp
+++ b/mock-idf/components/esp_wifi/esp_wifi.cpp
@@ -59,3 +59,9 @@ esp_err_t esp_wifi_get_mac(wifi_interface_t /*ifx*/, uint8_t mac[6])
 
     return ESP_OK;
 }
+
+esp_err_t esp_wifi_get_mode(wifi_mode_t * mode)
+{
+    *mode = WIFI_MODE_STA;
+    return ESP_OK;
+}

--- a/mock-idf/components/esp_wifi/include/esp_wifi.h
+++ b/mock-idf/components/esp_wifi/include/esp_wifi.h
@@ -28,3 +28,5 @@ esp_err_t esp_wifi_set_config(wifi_interface_t interface, wifi_config_t* conf);
 esp_err_t esp_wifi_connect();
 
 esp_err_t esp_wifi_get_mac(wifi_interface_t ifx, uint8_t mac[6]);
+
+esp_err_t esp_wifi_get_mode(wifi_mode_t * mode);

--- a/test/access_point/access_point.cpp
+++ b/test/access_point/access_point.cpp
@@ -99,8 +99,8 @@ namespace access_point
             Log::info("Tag",
             "loacal IP: {}.{}.{}.{}",
             ip >> 24,
-            (ip & 0x00FF0000) >> 16,
-            (ip & 0x0000FF00) >> 8,
+                      (ip & 0x00FF0000) >> 16,
+                      (ip & 0x0000FF00) >> 8,
             ip & 0xFF);
         }
 

--- a/test/access_point/access_point.cpp
+++ b/test/access_point/access_point.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include "access_point.h"
 #include <memory>
+#include <string>
+#include <fmt/format.h>
 #include <smooth/core/logging/log.h>
 #include <smooth/core/task_priorities.h>
 #include <smooth/core/network/IPv4.h>
@@ -80,7 +82,36 @@ namespace access_point
 
         insecure_server->start(max_client_count, listen_backlog, std::make_shared<IPv4>("0.0.0.0", 8080));
 
-        auto hello_world = [](
+        std::string str_response = "";
+
+        std::array<uint8_t, 6> mac;
+
+        if (wifi.get_local_mac_address(mac))
+        {
+            Log::info("Tag", "loacal MAC: {:X}:{:X}:{:X}:{:X}:{:X}:{:X}", mac[0], mac[1], mac[2], mac[3], mac[4],
+            mac[5]);
+        }
+
+        uint32_t ip = static_cast<uint32_t>(wifi.get_local_ip().addr);
+
+        if (ip)
+        {
+            Log::info("Tag",
+            "loacal IP: {}.{}.{}.{}",
+            ip >> 24,
+            (ip & 0x00FF0000) >> 16,
+            (ip & 0x0000FF00) >> 8,
+            ip & 0xFF);
+        }
+
+        std::string MAC = fmt::format("{:X}:{:X}:{:X}:{:X}:{:X}:{:X}", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        std::string IP =
+            fmt::format("{}.{}.{}.{}", ip >> 24, (ip & 0x00FF0000) >> 16, (ip & 0x0000FF00) >> 8, ip & 0xFF);
+        str_response = "<HTML><HEAD><TITLE>Hello World!</TITLE></HEAD><BODY><H1>Hello World!</H1>";
+        str_response += "Access point IP is: " + IP + "<br>";
+        str_response += "Access point MAC is:" + MAC + "</BODY></HTML>";
+
+        auto hello_world = [str_response](
             IServerResponse& response,
             IConnectionTimeoutModifier& /*timeout_modifier*/,
             const std::string& /*url*/,
@@ -94,7 +125,7 @@ namespace access_point
                                {
                                    response.reply(std::make_unique<responses::StringResponse>(
                                    ResponseCode::OK,
-                                   "<HTML><HEAD><TITLE>Hello World!</TITLE></HEAD><BODY><H1>Hello World!</H1></BODY></HTML>"),
+                                   str_response),
                                    false);
                                }
                            };


### PR DESCRIPTION
- bugfix for Wifi::get_mac_address() which now returns the right mac address of the used interface
- added Wifi:: get_local_mac_address(uint8_t m[6]) for getting the binary representation of the mac address
- added Wifi::get_local_ip() for getting the IP address of the ESP32