### PR TITLE
Added missing <cstdint> include for uint8_t

### DIFF
--- a/lib/smooth/include/smooth/core/network/IPacketDisassembly.h
+++ b/lib/smooth/include/smooth/core/network/IPacketDisassembly.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #pragma once
 
+#include <cstdint>
+
 namespace smooth::core::network
 {
     /// Interface for packets that can be disassembled into a series of bytes


### PR DESCRIPTION
This PR adds the missing include for `uint8_t`.
Without it derived classes do not compile.
```log
error: 'uint8_t' does not name a type
```