### PR TITLE
Add support for wired ethernet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 
 # Select the test project to build
-set(selected_test_project starter_example)
+set(selected_test_project server_socket_ethernet_test)
 
 # For Linux builds, you may enable address sanitizer
 set(SMOOTH_ENABLE_ASAN 0)
@@ -38,6 +38,7 @@ list(APPEND available_tests
         timer
         secure_socket_test
         server_socket_test
+        server_socket_ethernet_test
         secure_server_socket_test
         http_server_test
         http_files_upload_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 
 # Select the test project to build
-set(selected_test_project server_socket_ethernet_test)
+set(selected_test_project starter_example)
 
 # For Linux builds, you may enable address sanitizer
 set(SMOOTH_ENABLE_ASAN 0)

--- a/lib/files.cmake
+++ b/lib/files.cmake
@@ -85,9 +85,11 @@ set(SMOOTH_SOURCES
         ${smooth_dir}/core/json/JsonFile.cpp
         ${smooth_dir}/core/logging/log.cpp
         ${smooth_dir}/core/network/CommonSocket.cpp
+        ${smooth_dir}/core/network/Ethernet.cpp
         ${smooth_dir}/core/network/IPv4.cpp
         ${smooth_dir}/core/network/IPv6.cpp
         ${smooth_dir}/core/network/MbedTLSContext.cpp
+        ${smooth_dir}/core/network/NetworkInterface.cpp
         ${smooth_dir}/core/network/SocketDispatcher.cpp
         ${smooth_dir}/core/network/Wifi.cpp
         ${smooth_dir}/core/sntp/Sntp.cpp

--- a/lib/smooth/core/network/Ethernet.cpp
+++ b/lib/smooth/core/network/Ethernet.cpp
@@ -1,0 +1,226 @@
+/*
+Smooth - A C++ framework for embedded programming on top of Espressif's ESP-IDF
+Copyright 2019 Per Malmberg (https://gitbub.com/PerMalmberg)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "smooth/core/network/Ethernet.h"
+#include "smooth/core/ipc/Publisher.h"
+#include "smooth/core/logging/log.h"
+#include "smooth/core/network/NetworkStatus.h"
+#include "smooth/core/util/copy_min_to_buffer.h"
+#include <cstring>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#include <esp_eth.h>
+#include <esp_event.h>
+#include <esp_netif.h>
+#pragma GCC diagnostic pop
+
+#ifdef ESP_PLATFORM
+#include "sdkconfig.h"
+static_assert(CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE >= 3072,
+              "Need enough stack to be able to log in the event loop callback.");
+#endif
+
+using namespace smooth::core::util;
+using namespace smooth::core;
+
+namespace smooth::core::network {
+
+Ethernet::Ethernet(std::string name)
+    : NetworkInterface(std::move(name))
+{
+}
+
+Ethernet::~Ethernet()
+{
+    deinit();
+}
+
+bool
+Ethernet::init()
+{
+    esp_err_t err = do_init();
+    if (err != ESP_OK) {
+        Log::error(interface_name, "init", esp_err_to_name(err));
+        return false;
+    }
+    return true;
+}
+
+void
+Ethernet::deinit()
+{
+    esp_event_handler_instance_unregister(IP_EVENT, ESP_EVENT_ANY_ID, instance_ip_event);
+    esp_event_handler_instance_unregister(ETH_EVENT, ESP_EVENT_ANY_ID, instance_eth_event);
+    if (eth_handle) {
+        esp_eth_stop(eth_handle);
+    }
+}
+
+esp_err_t
+Ethernet::do_init()
+{
+    esp_err_t err = ESP_OK;
+
+    esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
+    interface = esp_netif_new(&cfg);
+    err = esp_eth_set_default_handlers(interface);
+    if (err != ESP_OK) {
+        return err;
+    }
+    esp_event_handler_instance_register(ETH_EVENT,
+                                        ESP_EVENT_ANY_ID,
+                                        &Ethernet::eth_event_callback,
+                                        this,
+                                        &instance_eth_event);
+
+    esp_event_handler_instance_register(IP_EVENT,
+                                        ESP_EVENT_ANY_ID,
+                                        &Ethernet::eth_event_callback,
+                                        this,
+                                        &instance_ip_event);
+
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+
+    phy_config.phy_addr = CONFIG_EXAMPLE_ETH_PHY_ADDR;
+    phy_config.reset_gpio_num = CONFIG_EXAMPLE_ETH_PHY_RST_GPIO;
+#if CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET
+    mac_config.smi_mdc_gpio_num = CONFIG_EXAMPLE_ETH_MDC_GPIO;
+    mac_config.smi_mdio_gpio_num = CONFIG_EXAMPLE_ETH_MDIO_GPIO;
+    mac = esp_eth_mac_new_esp32(&mac_config);
+#if CONFIG_EXAMPLE_ETH_PHY_IP101
+    phy = esp_eth_phy_new_ip101(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_RTL8201
+    phy = esp_eth_phy_new_rtl8201(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_LAN8720
+    phy = esp_eth_phy_new_lan8720(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_LAN8742
+    phy = esp_eth_phy_new_lan8742(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_DP83848
+    phy = esp_eth_phy_new_dp83848(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_KSZ8041
+    phy = esp_eth_phy_new_ksz8041(&phy_config);
+#endif
+#elif CONFIG_EXAMPLE_USE_DM9051
+    gpio_install_isr_service(0);
+    spi_device_handle_t spi_handle = NULL;
+    spi_bus_config_t buscfg = {
+        .miso_io_num = CONFIG_EXAMPLE_DM9051_MISO_GPIO,
+        .mosi_io_num = CONFIG_EXAMPLE_DM9051_MOSI_GPIO,
+        .sclk_io_num = CONFIG_EXAMPLE_DM9051_SCLK_GPIO,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+    };
+    err = spi_bus_initialize(CONFIG_EXAMPLE_DM9051_SPI_HOST, &buscfg, 1);
+    if (err != ESP_OK) {
+        return err;
+    }
+    spi_device_interface_config_t = devcfg = {
+        .command_bits = 1,
+        .address_bits = 7,
+        .mode = 0,
+        .clock_speed_hz = CONFIG_EXAMPLE_DM9051_SPI_CLOCK_MHZ * 1000 * 1000,
+        .spics_io_num = CONFIG_EXAMPLE_DM9051_CS_GPIO,
+        .queue_size = 20};
+    err = spi_bus_add_device(CONFIG_EXAMPLE_DM9051_SPI_HOST, &devcfg, &spi_handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+    /* dm9051 ethernet driver is based on spi driver */
+    eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(spi_handle);
+    dm9051_config.int_gpio_num = CONFIG_EXAMPLE_DM9051_INT_GPIO;
+    mac = esp_eth_mac_new_dm9051(&dm9051_config, &mac_config);
+    phy = esp_eth_phy_new_dm9051(&phy_config);
+#endif
+    esp_eth_config_t config = ETH_DEFAULT_CONFIG(mac, phy);
+    err = esp_eth_driver_install(&config, &eth_handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+    /* attach Ethernet driver to TCP/IP stack */
+    err = esp_netif_attach(interface, esp_eth_new_netif_glue(eth_handle));
+    if (err != ESP_OK) {
+        return err;
+    }
+    /* start Ethernet driver state machine */
+    err = esp_eth_start(eth_handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    return err;
+}
+
+bool
+Ethernet::is_connected() const
+{
+    return connected;
+}
+
+void
+Ethernet::eth_event_callback(void* event_handler_arg,
+                             esp_event_base_t event_base,
+                             int32_t event_id,
+                             void* event_data)
+{
+    // Note: be very careful with what you do in this method - it runs under the event task
+    // (sys_evt) with a very small default stack.
+    Ethernet* eth = reinterpret_cast<Ethernet*>(event_handler_arg);
+
+    if (event_base == ETH_EVENT) {
+        switch (event_id) {
+
+        case ETHERNET_EVENT_START:
+            break;
+        case ETHERNET_EVENT_STOP:
+            eth->ip.addr = 0;
+            publish_status(false, true);
+            break;
+        case ETHERNET_EVENT_CONNECTED:
+            eth->connected = true;
+            break;
+        case ETHERNET_EVENT_DISCONNECTED:
+            eth->ip.addr = 0;
+            eth->connected = false;
+            publish_status(eth->connected, true);
+            break;
+        }
+    } else if (event_base == IP_EVENT) {
+        if (event_id == IP_EVENT_STA_GOT_IP
+            || event_id == IP_EVENT_GOT_IP6
+            || event_id == IP_EVENT_ETH_GOT_IP) {
+            auto ip_changed = event_id == IP_EVENT_STA_GOT_IP ? reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_changed : true;
+            publish_status(true, ip_changed);
+            eth->ip.addr = reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_info.ip.addr;
+        } else if (event_id == IP_EVENT_STA_LOST_IP) {
+            eth->ip.addr = 0;
+            publish_status(false, true);
+        }
+    }
+}
+
+void
+Ethernet::publish_status(bool connected, bool ip_changed)
+{
+    network::NetworkStatus status(connected
+                                      ? network::NetworkEvent::GOT_IP
+                                      : network::NetworkEvent::DISCONNECTED,
+                                  ip_changed);
+    core::ipc::Publisher<network::NetworkStatus>::publish(status);
+}
+}

--- a/lib/smooth/core/network/Ethernet.cpp
+++ b/lib/smooth/core/network/Ethernet.cpp
@@ -67,7 +67,9 @@ namespace smooth::core::network {
         mac_config.smi_mdc_gpio_num = CONFIG_SMOOTH_ETH_MDC_GPIO;
         mac_config.smi_mdio_gpio_num = CONFIG_SMOOTH_ETH_MDIO_GPIO;
         mac = esp_eth_mac_new_esp32(&mac_config);
-#if CONFIG_SMOOTH_ETH_PHY_IP101
+#if CONFIG_SMOOTH_ETH_PHY_MOCK
+        phy = esp_eth_phy_new_mock(&phy_config);
+#elif CONFIG_SMOOTH_ETH_PHY_IP101
         phy = esp_eth_phy_new_ip101(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_RTL8201
         phy = esp_eth_phy_new_rtl8201(&phy_config);
@@ -79,8 +81,6 @@ namespace smooth::core::network {
         phy = esp_eth_phy_new_dp83848(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_KSZ8041
         phy = esp_eth_phy_new_ksz8041(&phy_config);
-#elif CONFIG_SMOOTH_ETH_PHY_MOCK
-        phy = esp_eth_phy_new_mock(&phy_config);
 #else
 #error CONFIG_SMOOTH_ETH_PHY_type not set
 #endif

--- a/lib/smooth/core/network/Ethernet.cpp
+++ b/lib/smooth/core/network/Ethernet.cpp
@@ -39,165 +39,182 @@ using namespace smooth::core::util;
 using namespace smooth::core;
 
 namespace smooth::core::network {
+    Ethernet::Ethernet(std::string&& name)
+            : NetworkInterface(std::move(name))
+    {
+        esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
+        interface = esp_netif_new(&cfg);
+        esp_eth_set_default_handlers(interface);
 
-Ethernet::Ethernet(std::string&& name)
-    : NetworkInterface(std::move(name))
-{
-    esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
-    interface = esp_netif_new(&cfg);
-    esp_eth_set_default_handlers(interface);
-
-    esp_event_handler_instance_register(ETH_EVENT,
+        esp_event_handler_instance_register(ETH_EVENT,
                                         ESP_EVENT_ANY_ID,
                                         &Ethernet::eth_event_callback,
                                         this,
                                         &instance_eth_event);
 
-    esp_event_handler_instance_register(IP_EVENT,
+        esp_event_handler_instance_register(IP_EVENT,
                                         ESP_EVENT_ANY_ID,
                                         &Ethernet::eth_event_callback,
                                         this,
                                         &instance_ip_event);
 
-    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
-    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
-    phy_config.phy_addr = CONFIG_SMOOTH_ETH_PHY_ADDR;
-    phy_config.reset_gpio_num = CONFIG_SMOOTH_ETH_PHY_RST_GPIO;
+        eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+        eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+        phy_config.phy_addr = CONFIG_SMOOTH_ETH_PHY_ADDR;
+        phy_config.reset_gpio_num = CONFIG_SMOOTH_ETH_PHY_RST_GPIO;
 #if CONFIG_SMOOTH_USE_INTERNAL_ETHERNET
-    mac_config.smi_mdc_gpio_num = CONFIG_SMOOTH_ETH_MDC_GPIO;
-    mac_config.smi_mdio_gpio_num = CONFIG_SMOOTH_ETH_MDIO_GPIO;
-    mac = esp_eth_mac_new_esp32(&mac_config);
+        mac_config.smi_mdc_gpio_num = CONFIG_SMOOTH_ETH_MDC_GPIO;
+        mac_config.smi_mdio_gpio_num = CONFIG_SMOOTH_ETH_MDIO_GPIO;
+        mac = esp_eth_mac_new_esp32(&mac_config);
 #if CONFIG_SMOOTH_ETH_PHY_IP101
-    phy = esp_eth_phy_new_ip101(&phy_config);
+        phy = esp_eth_phy_new_ip101(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_RTL8201
-    phy = esp_eth_phy_new_rtl8201(&phy_config);
+        phy = esp_eth_phy_new_rtl8201(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_LAN8720
-    phy = esp_eth_phy_new_lan8720(&phy_config);
+        phy = esp_eth_phy_new_lan8720(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_LAN8742
-    phy = esp_eth_phy_new_lan8742(&phy_config);
+        phy = esp_eth_phy_new_lan8742(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_DP83848
-    phy = esp_eth_phy_new_dp83848(&phy_config);
+        phy = esp_eth_phy_new_dp83848(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_KSZ8041
-    phy = esp_eth_phy_new_ksz8041(&phy_config);
+        phy = esp_eth_phy_new_ksz8041(&phy_config);
 #else
 #error CONFIG_SMOOTH_ETH_PHY_type not set
 #endif
 #elif CONFIG_SMOOTH_USE_DM9051
-    gpio_install_isr_service(0);
-    spi_device_handle_t spi_handle = NULL;
-    spi_bus_config_t buscfg = {
-        .miso_io_num = CONFIG_SMOOTH_DM9051_MISO_GPIO,
-        .mosi_io_num = CONFIG_SMOOTH_DM9051_MOSI_GPIO,
-        .sclk_io_num = CONFIG_SMOOTH_DM9051_SCLK_GPIO,
-        .quadwp_io_num = -1,
-        .quadhd_io_num = -1,
-    };
-    spi_bus_initialize(CONFIG_SMOOTH_DM9051_SPI_HOST, &buscfg, 1);
-    if (err != ESP_OK) {
-        return err;
-    }
-    spi_device_interface_config_t = devcfg = {
-        .command_bits = 1,
-        .address_bits = 7,
-        .mode = 0,
-        .clock_speed_hz = CONFIG_SMOOTH_DM9051_SPI_CLOCK_MHZ * 1000 * 1000,
-        .spics_io_num = CONFIG_SMOOTH_DM9051_CS_GPIO,
-        .queue_size = 20};
-    spi_bus_add_device(CONFIG_SMOOTH_DM9051_SPI_HOST, &devcfg, &spi_handle);
-    if (err != ESP_OK) {
-        return err;
-    }
-    /* dm9051 ethernet driver is based on spi driver */
-    eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(spi_handle);
-    dm9051_config.int_gpio_num = CONFIG_SMOOTH_DM9051_INT_GPIO;
-    mac = esp_eth_mac_new_dm9051(&dm9051_config, &mac_config);
-    phy = esp_eth_phy_new_dm9051(&phy_config);
+        gpio_install_isr_service(0);
+        spi_device_handle_t spi_handle = NULL;
+        spi_bus_config_t buscfg = {
+            .miso_io_num = CONFIG_SMOOTH_DM9051_MISO_GPIO,
+            .mosi_io_num = CONFIG_SMOOTH_DM9051_MOSI_GPIO,
+            .sclk_io_num = CONFIG_SMOOTH_DM9051_SCLK_GPIO,
+            .quadwp_io_num = -1,
+            .quadhd_io_num = -1,
+        };
+        spi_bus_initialize(CONFIG_SMOOTH_DM9051_SPI_HOST, &buscfg, 1);
+
+        if (err != ESP_OK)
+        {
+            return err;
+        }
+
+        spi_device_interface_config_t = devcfg = {
+            .command_bits = 1,
+            .address_bits = 7,
+            .mode = 0,
+            .clock_speed_hz = CONFIG_SMOOTH_DM9051_SPI_CLOCK_MHZ * 1000 * 1000,
+            .spics_io_num = CONFIG_SMOOTH_DM9051_CS_GPIO,
+            .queue_size = 20 };
+        spi_bus_add_device(CONFIG_SMOOTH_DM9051_SPI_HOST, &devcfg, &spi_handle);
+
+        if (err != ESP_OK)
+        {
+            return err;
+        }
+
+        /* dm9051 ethernet driver is based on spi driver */
+        eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(spi_handle);
+        dm9051_config.int_gpio_num = CONFIG_SMOOTH_DM9051_INT_GPIO;
+        mac = esp_eth_mac_new_dm9051(&dm9051_config, &mac_config);
+        phy = esp_eth_phy_new_dm9051(&phy_config);
 #else
 #error CONFIG_SMOOTH_USE_INTERNAL_ETHERNET or CONFIG_SMOOTH_USE_DM9051 should be set
 #endif
-    esp_eth_config_t config = ETH_DEFAULT_CONFIG(mac, phy);
-    esp_eth_driver_install(&config, &eth_handle);
-}
-
-Ethernet::~Ethernet()
-{
-    esp_event_handler_instance_unregister(IP_EVENT, ESP_EVENT_ANY_ID, instance_ip_event);
-    esp_event_handler_instance_unregister(ETH_EVENT, ESP_EVENT_ANY_ID, instance_eth_event);
-    if (eth_handle) {
-        esp_eth_stop(eth_handle);
-    }
-}
-
-void
-Ethernet::start()
-{
-    apply_host_name();
-    auto err = esp_netif_attach(interface, esp_eth_new_netif_glue(eth_handle));
-    if (err == ESP_OK) {
-        /* start Ethernet driver state machine */
-        err = esp_eth_start(eth_handle);
+        esp_eth_config_t config = ETH_DEFAULT_CONFIG(mac, phy);
+        esp_eth_driver_install(&config, &eth_handle);
     }
 
-    if (err != ESP_OK) {
-        Log::error(interface_name, "start", esp_err_to_name(err));
-    }
-}
+    Ethernet::~Ethernet()
+    {
+        esp_event_handler_instance_unregister(IP_EVENT, ESP_EVENT_ANY_ID, instance_ip_event);
+        esp_event_handler_instance_unregister(ETH_EVENT, ESP_EVENT_ANY_ID, instance_eth_event);
 
-bool
-Ethernet::is_connected() const
-{
-    return connected;
-}
-
-void
-Ethernet::eth_event_callback(void* event_handler_arg,
-                             esp_event_base_t event_base,
-                             int32_t event_id,
-                             void* event_data)
-{
-    // Note: be very careful with what you do in this method - it runs under the event task
-    // (sys_evt) with a very small default stack.
-    Ethernet* eth = reinterpret_cast<Ethernet*>(event_handler_arg);
-
-    if (event_base == ETH_EVENT) {
-        switch (event_id) {
-
-        case ETHERNET_EVENT_START:
-            break;
-        case ETHERNET_EVENT_STOP:
-            eth->ip.addr = 0;
-            publish_status(false, true);
-            break;
-        case ETHERNET_EVENT_CONNECTED:
-            eth->connected = true;
-            break;
-        case ETHERNET_EVENT_DISCONNECTED:
-            eth->ip.addr = 0;
-            eth->connected = false;
-            publish_status(eth->connected, true);
-            break;
-        }
-    } else if (event_base == IP_EVENT) {
-        if (event_id == IP_EVENT_STA_GOT_IP
-            || event_id == IP_EVENT_GOT_IP6
-            || event_id == IP_EVENT_ETH_GOT_IP) {
-            auto ip_changed = event_id == IP_EVENT_STA_GOT_IP ? reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_changed : true;
-            publish_status(true, ip_changed);
-            eth->ip.addr = reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_info.ip.addr;
-        } else if (event_id == IP_EVENT_STA_LOST_IP) {
-            eth->ip.addr = 0;
-            publish_status(false, true);
+        if (eth_handle)
+        {
+            esp_eth_stop(eth_handle);
         }
     }
-}
 
-void
-Ethernet::publish_status(bool connected, bool ip_changed)
-{
-    network::NetworkStatus status(connected
+    void Ethernet::start()
+    {
+        apply_host_name();
+        auto err = esp_netif_attach(interface, esp_eth_new_netif_glue(eth_handle));
+
+        if (err == ESP_OK)
+        {
+            /* start Ethernet driver state machine */
+            err = esp_eth_start(eth_handle);
+        }
+
+        if (err != ESP_OK)
+        {
+            Log::error(interface_name, "start", esp_err_to_name(err));
+        }
+    }
+
+    bool Ethernet::is_connected() const
+    {
+        return connected;
+    }
+
+    void Ethernet::eth_event_callback(void* event_handler_arg,
+                                      esp_event_base_t event_base,
+                                      int32_t event_id,
+                                      void* event_data)
+    {
+        // Note: be very careful with what you do in this method - it runs under the event task
+        // (sys_evt) with a very small default stack.
+        Ethernet* eth = reinterpret_cast<Ethernet*>(event_handler_arg);
+
+        if (event_base == ETH_EVENT)
+        {
+            switch (event_id) {
+            case ETHERNET_EVENT_START: {
+            }
+            break;
+            case ETHERNET_EVENT_STOP: {
+                eth->ip.addr = 0;
+                publish_status(false, true);
+            }
+            break;
+            case ETHERNET_EVENT_CONNECTED: {
+                eth->connected = true;
+            }
+            break;
+            case ETHERNET_EVENT_DISCONNECTED: {
+                eth->ip.addr = 0;
+                eth->connected = false;
+                publish_status(eth->connected, true);
+            }
+            break;
+            }
+        }
+        else if (event_base == IP_EVENT)
+        {
+            if (event_id == IP_EVENT_STA_GOT_IP
+                || event_id == IP_EVENT_GOT_IP6
+                || event_id == IP_EVENT_ETH_GOT_IP)
+            {
+                auto ip_changed = event_id ==
+                                  IP_EVENT_STA_GOT_IP ? reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_changed :
+                                  true;
+                publish_status(true, ip_changed);
+                eth->ip.addr = reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_info.ip.addr;
+            }
+            else if (event_id == IP_EVENT_STA_LOST_IP)
+            {
+                eth->ip.addr = 0;
+                publish_status(false, true);
+            }
+        }
+    }
+
+    void Ethernet::publish_status(bool connected, bool ip_changed)
+    {
+        network::NetworkStatus status(connected
                                       ? network::NetworkEvent::GOT_IP
                                       : network::NetworkEvent::DISCONNECTED,
-                                  ip_changed);
-    core::ipc::Publisher<network::NetworkStatus>::publish(status);
-}
+                                      ip_changed);
+        core::ipc::Publisher<network::NetworkStatus>::publish(status);
+    }
 }

--- a/lib/smooth/core/network/Ethernet.cpp
+++ b/lib/smooth/core/network/Ethernet.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <esp_eth.h>
+#include <esp_eth_netif_glue.h>
 #include <esp_event.h>
 #include <esp_netif.h>
 #pragma GCC diagnostic pop
@@ -78,6 +79,8 @@ namespace smooth::core::network {
         phy = esp_eth_phy_new_dp83848(&phy_config);
 #elif CONFIG_SMOOTH_ETH_PHY_KSZ8041
         phy = esp_eth_phy_new_ksz8041(&phy_config);
+#elif CONFIG_SMOOTH_ETH_PHY_MOCK
+        phy = esp_eth_phy_new_mock(&phy_config);
 #else
 #error CONFIG_SMOOTH_ETH_PHY_type not set
 #endif

--- a/lib/smooth/core/network/NetworkInterface.cpp
+++ b/lib/smooth/core/network/NetworkInterface.cpp
@@ -1,0 +1,86 @@
+#include "smooth/core/network/NetworkInterface.h"
+#include "smooth/core/logging/log.h"
+#include <sstream>
+
+using namespace smooth::core::logging;
+
+namespace smooth::core::network {
+uint8_t NetworkInterface::interface_count = 0;
+
+NetworkInterface::NetworkInterface(std::string name)
+    : interface_name(name)
+{
+    if (interface_count == 0) {
+        esp_netif_init();
+    }
+    ++interface_count;
+}
+
+NetworkInterface::~NetworkInterface()
+{
+    --interface_count;
+    if (interface_count == 0) {
+        esp_netif_deinit();
+    }
+};
+
+void
+NetworkInterface::set_host_name(const std::string& name)
+{
+    esp_netif_set_hostname(interface, name.c_str());
+}
+
+void
+NetworkInterface::close_if()
+{
+    if (interface) {
+        esp_netif_destroy(interface);
+        interface = nullptr;
+    }
+}
+
+// attention: access to this function might have a threading issue.
+// It should be called from the main thread only!
+uint32_t
+NetworkInterface::get_local_ip() const
+{
+    return ip.addr;
+}
+
+bool
+NetworkInterface::get_local_mac_address(std::array<uint8_t, 6>& m) const
+{
+    if (interface) {
+        esp_err_t err = esp_netif_get_mac(interface, m.data());
+
+        if (err != ESP_OK) {
+            Log::error(interface_name, "get_local_mac_address(): {}", esp_err_to_name(err));
+            return false;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+std::string
+NetworkInterface::get_mac_address() const
+{
+    std::stringstream mac;
+
+    std::array<uint8_t, 6> m;
+    bool ret = get_local_mac_address(m);
+
+    if (ret) {
+        for (const auto& v : m) {
+            if (mac.tellp() > 0) {
+                mac << "_";
+            }
+
+            mac << std::hex << static_cast<int>(v);
+        }
+    }
+
+    return mac.str();
+}
+}

--- a/lib/smooth/core/network/NetworkInterface.cpp
+++ b/lib/smooth/core/network/NetworkInterface.cpp
@@ -1,5 +1,7 @@
 #include "smooth/core/network/NetworkInterface.h"
 #include "smooth/core/logging/log.h"
+#include <esp_err.h>
+#include <esp_netif.h>
 #include <sstream>
 
 using namespace smooth::core::logging;

--- a/lib/smooth/core/network/NetworkInterface.cpp
+++ b/lib/smooth/core/network/NetworkInterface.cpp
@@ -5,84 +5,91 @@
 using namespace smooth::core::logging;
 
 namespace smooth::core::network {
-uint8_t NetworkInterface::interface_count = 0;
+    uint8_t NetworkInterface::interface_count = 0;
 
-NetworkInterface::NetworkInterface(std::string&& name)
-    : interface_name(name)
-{
-    if (interface_count == 0) {
-        esp_netif_init();
+    NetworkInterface::NetworkInterface(std::string&& name)
+            : interface_name(name)
+    {
+        if (interface_count == 0)
+        {
+            esp_netif_init();
+        }
+
+        ++interface_count;
     }
-    ++interface_count;
-}
 
-NetworkInterface::~NetworkInterface()
-{
-    --interface_count;
-    if (interface_count == 0) {
-        esp_netif_deinit();
+    NetworkInterface::~NetworkInterface()
+    {
+        --interface_count;
+
+        if (interface_count == 0)
+        {
+            esp_netif_deinit();
+        }
     }
-};
 
-void
-NetworkInterface::set_host_name(const std::string& name)
-{
-    // this only sets the host name string.
-    // before network interface is started in subclass, it should call apply_host_name
-    auto copied = name.copy(host_name, 32);
-    host_name[copied] = 0; // null terminate
-}
-
-void
-NetworkInterface::apply_host_name()
-{
-    if (interface) {
-        esp_netif_set_hostname(interface, host_name);
+    void NetworkInterface::set_host_name(const std::string& name)
+    {
+        // this only sets the host name string.
+        // before network interface is started in subclass, it should call apply_host_name
+        auto copied = name.copy(host_name, 32);
+        host_name[copied] = 0; // null terminate
     }
-}
+
+    void NetworkInterface::apply_host_name()
+    {
+        if (interface)
+        {
+            esp_netif_set_hostname(interface, host_name);
+        }
+    }
 
 // attention: access to this function might have a threading issue.
 // It should be called from the main thread only!
-uint32_t
-NetworkInterface::get_local_ip() const
-{
-    return ip.addr;
-}
-
-bool
-NetworkInterface::get_local_mac_address(std::array<uint8_t, 6>& m) const
-{
-    if (interface) {
-        esp_err_t err = esp_netif_get_mac(interface, m.data());
-
-        if (err != ESP_OK) {
-            Log::error(interface_name, "get_local_mac_address(): {}", esp_err_to_name(err));
-            return false;
-        }
-        return true;
+    uint32_t NetworkInterface::get_local_ip() const
+    {
+        return ip.addr;
     }
 
-    return false;
-}
+    bool NetworkInterface::get_local_mac_address(std::array<uint8_t, 6>& m) const
+    {
+        if (interface)
+        {
+            esp_err_t err = esp_netif_get_mac(interface, m.data());
 
-std::string
-NetworkInterface::get_mac_address() const
-{
-    std::stringstream mac;
+            if (err != ESP_OK)
+            {
+                Log::error(interface_name, "get_local_mac_address(): {}", esp_err_to_name(err));
 
-    std::array<uint8_t, 6> m;
-    bool ret = get_local_mac_address(m);
-
-    if (ret) {
-        for (const auto& v : m) {
-            if (mac.tellp() > 0) {
-                mac << "_";
+                return false;
             }
 
-            mac << std::hex << static_cast<int>(v);
+            return true;
         }
+
+        return false;
     }
 
-    return mac.str();
-}
+    std::string NetworkInterface::get_mac_address() const
+    {
+        std::stringstream mac;
+
+        std::array<uint8_t, 6> m;
+        bool ret = get_local_mac_address(m);
+
+        if (ret)
+        {
+            for (const auto& v : m)
+            {
+                if (mac.tellp() > 0)
+                {
+                    mac << "_";
+                }
+
+                mac << std::hex << static_cast<int>(v);
+            }
+        }
+
+        return mac.str();
+    }
 }

--- a/lib/smooth/core/network/NetworkInterface.cpp
+++ b/lib/smooth/core/network/NetworkInterface.cpp
@@ -7,7 +7,7 @@ using namespace smooth::core::logging;
 namespace smooth::core::network {
 uint8_t NetworkInterface::interface_count = 0;
 
-NetworkInterface::NetworkInterface(std::string name)
+NetworkInterface::NetworkInterface(std::string&& name)
     : interface_name(name)
 {
     if (interface_count == 0) {
@@ -27,15 +27,17 @@ NetworkInterface::~NetworkInterface()
 void
 NetworkInterface::set_host_name(const std::string& name)
 {
-    esp_netif_set_hostname(interface, name.c_str());
+    // this only sets the host name string.
+    // before network interface is started in subclass, it should call apply_host_name
+    auto copied = name.copy(host_name, 32);
+    host_name[copied] = 0; // null terminate
 }
 
 void
-NetworkInterface::close_if()
+NetworkInterface::apply_host_name()
 {
     if (interface) {
-        esp_netif_destroy(interface);
-        interface = nullptr;
+        esp_netif_set_hostname(interface, host_name);
     }
 }
 

--- a/lib/smooth/core/network/Wifi.cpp
+++ b/lib/smooth/core/network/Wifi.cpp
@@ -35,7 +35,7 @@ using namespace smooth::core::util;
 using namespace smooth::core;
 
 namespace smooth::core::network {
-Wifi::Wifi(std::string name)
+Wifi::Wifi(std::string&& name)
     : NetworkInterface(std::move(name))
 {
     esp_event_handler_instance_register(WIFI_EVENT,
@@ -94,7 +94,7 @@ Wifi::connect_to_ap()
 
     close_if();
     interface = esp_netif_create_default_wifi_sta();
-
+    apply_host_name();
     connect();
 }
 
@@ -189,6 +189,15 @@ Wifi::wifi_event_callback(void* event_handler_arg,
             wifi->ip.addr = 0;
             publish_status(false, true);
         }
+    }
+}
+
+void
+Wifi::close_if()
+{
+    if (interface) {
+        esp_netif_destroy(interface);
+        interface = nullptr;
     }
 }
 

--- a/lib/smooth/core/network/Wifi.cpp
+++ b/lib/smooth/core/network/Wifi.cpp
@@ -247,4 +247,11 @@ namespace smooth::core::network {
                                       ip_changed);
         core::ipc::Publisher<network::NetworkStatus>::publish(status);
     }
+
+    Wifi& get_wifi()
+    {
+        static Wifi* wifi = new Wifi();
+
+        return *wifi;
+    }
 }

--- a/lib/smooth/core/network/Wifi.cpp
+++ b/lib/smooth/core/network/Wifi.cpp
@@ -16,301 +16,219 @@ limitations under the License.
 */
 
 #include "smooth/core/network/Wifi.h"
-#include <cstring>
-#include <sstream>
-#include <esp_wifi_types.h>
-#include <esp_netif.h>
-#include <esp_event.h>
-#include "smooth/core/network/NetworkStatus.h"
 #include "smooth/core/ipc/Publisher.h"
-#include "smooth/core/util/copy_min_to_buffer.h"
 #include "smooth/core/logging/log.h"
+#include "smooth/core/network/NetworkStatus.h"
+#include "smooth/core/util/copy_min_to_buffer.h"
+#include <cstring>
+#include <esp_event.h>
+#include <esp_netif.h>
+#include <esp_wifi_types.h>
 
 #ifdef ESP_PLATFORM
 #include "sdkconfig.h"
 static_assert(CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE >= 3072,
-"Need enough stack to be able to log in the event loop callback.");
+              "Need enough stack to be able to log in the event loop callback.");
 #endif
 
 using namespace smooth::core::util;
 using namespace smooth::core;
 
-namespace smooth::core::network
+namespace smooth::core::network {
+Wifi::Wifi(std::string name)
+    : NetworkInterface(std::move(name))
 {
-    struct esp_ip4_addr Wifi::ip = { 0 };
+    esp_event_handler_instance_register(WIFI_EVENT,
+                                        ESP_EVENT_ANY_ID,
+                                        &Wifi::wifi_event_callback,
+                                        this,
+                                        &instance_wifi_event);
 
-    Wifi::Wifi()
-    {
-        esp_netif_init();
-        esp_event_handler_instance_register(WIFI_EVENT,
-                                           ESP_EVENT_ANY_ID,
-                                           &Wifi::wifi_event_callback,
-                                           this,
-                                           &instance_wifi_event);
+    esp_event_handler_instance_register(IP_EVENT,
+                                        ESP_EVENT_ANY_ID,
+                                        &Wifi::wifi_event_callback,
+                                        this,
+                                        &instance_ip_event);
+}
 
-        esp_event_handler_instance_register(IP_EVENT,
-                                           ESP_EVENT_ANY_ID,
-                                           &Wifi::wifi_event_callback,
-                                           this,
-                                           &instance_ip_event);
-    }
+Wifi::~Wifi()
+{
+    esp_event_handler_instance_unregister(IP_EVENT, ESP_EVENT_ANY_ID, instance_ip_event);
+    esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, instance_wifi_event);
+    esp_wifi_disconnect();
+    esp_wifi_stop();
+    esp_wifi_deinit();
+}
 
-    Wifi::~Wifi()
-    {
-        esp_event_handler_instance_unregister(IP_EVENT, ESP_EVENT_ANY_ID, instance_ip_event);
-        esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, instance_wifi_event);
-        esp_wifi_disconnect();
-        esp_wifi_stop();
-        esp_wifi_deinit();
-        esp_netif_deinit();
-    }
+void
+Wifi::set_ap_credentials(const std::string& wifi_ssid, const std::string& wifi_password)
+{
+    this->ssid = wifi_ssid;
+    this->password = wifi_password;
+}
 
-    void Wifi::set_host_name(const std::string& name)
-    {
-        host_name = name;
-    }
+void
+Wifi::set_auto_connect(bool auto_connect)
+{
+    auto_connect_to_ap = auto_connect;
+}
 
-    void Wifi::set_ap_credentials(const std::string& wifi_ssid, const std::string& wifi_password)
-    {
-        this->ssid = wifi_ssid;
-        this->password = wifi_password;
-    }
+void
+Wifi::connect_to_ap()
+{
+    // Prepare to connect to the provided SSID and password
+    wifi_init_config_t init = WIFI_INIT_CONFIG_DEFAULT();
+    esp_wifi_init(&init);
+    esp_wifi_set_mode(WIFI_MODE_STA);
 
-    void Wifi::set_auto_connect(bool auto_connect)
-    {
-        auto_connect_to_ap = auto_connect;
-    }
+    wifi_config_t config;
+    memset(&config, 0, sizeof(config));
+    copy_min_to_buffer(ssid.begin(), ssid.length(), config.sta.ssid);
+    copy_min_to_buffer(password.begin(), password.length(), config.sta.password);
 
-    void Wifi::connect_to_ap()
-    {
-        // Prepare to connect to the provided SSID and password
-        wifi_init_config_t init = WIFI_INIT_CONFIG_DEFAULT();
-        esp_wifi_init(&init);
-        esp_wifi_set_mode(WIFI_MODE_STA);
+    config.sta.bssid_set = false;
 
-        wifi_config_t config;
-        memset(&config, 0, sizeof(config));
-        copy_min_to_buffer(ssid.begin(), ssid.length(), config.sta.ssid);
-        copy_min_to_buffer(password.begin(), password.length(), config.sta.password);
+    // Store Wifi settings in RAM - it is the applications responsibility to store settings.
+    esp_wifi_set_storage(WIFI_STORAGE_RAM);
+    esp_wifi_set_config(WIFI_IF_STA, &config);
 
-        config.sta.bssid_set = false;
+    close_if();
+    interface = esp_netif_create_default_wifi_sta();
 
-        // Store Wifi settings in RAM - it is the applications responsibility to store settings.
-        esp_wifi_set_storage(WIFI_STORAGE_RAM);
-        esp_wifi_set_config(WIFI_IF_STA, &config);
+    connect();
+}
 
-        close_if();
-        interface = esp_netif_create_default_wifi_sta();
-
-        connect();
-    }
-
-    void Wifi::connect() const
-    {
+void
+Wifi::connect() const
+{
 #ifdef ESP_PLATFORM
-        esp_wifi_start();
-        esp_wifi_connect();
+    esp_wifi_start();
+    esp_wifi_connect();
 #else
 
-        // Assume network is available when running under POSIX system.
-        publish_status(true, true);
+    // Assume network is available when running under POSIX system.
+    publish_status(true, true);
 #endif
-    }
+}
 
-    bool Wifi::is_connected_to_ap() const
-    {
-        return connected_to_ap;
-    }
+bool
+Wifi::is_connected_to_ap() const
+{
+    return connected;
+}
 
-    void Wifi::wifi_event_callback(void* event_handler_arg,
-                                   esp_event_base_t event_base,
-                                   int32_t event_id,
-                                   void* event_data)
-    {
-        // Note: be very careful with what you do in this method - it runs under the event task
-        // (sys_evt) with a very small default stack.
-        Wifi* wifi = reinterpret_cast<Wifi*>(event_handler_arg);
+void
+Wifi::wifi_event_callback(void* event_handler_arg,
+                          esp_event_base_t event_base,
+                          int32_t event_id,
+                          void* event_data)
+{
+    // Note: be very careful with what you do in this method - it runs under the event task
+    // (sys_evt) with a very small default stack.
+    Wifi* wifi = reinterpret_cast<Wifi*>(event_handler_arg);
 
-        if (event_base == WIFI_EVENT)
-        {
-            if (event_id == WIFI_EVENT_STA_START)
-            {
-                esp_netif_set_hostname(wifi->interface, wifi->host_name.c_str());
-            }
-            else if (event_id == WIFI_EVENT_STA_CONNECTED)
-            {
-                wifi->connected_to_ap = true;
-            }
-            else if (event_id == WIFI_EVENT_STA_DISCONNECTED)
-            {
-                wifi->ip.addr = 0;
-                wifi->connected_to_ap = false;
-                publish_status(wifi->connected_to_ap, true);
+    if (event_base == WIFI_EVENT) {
+        switch (event_id) {
+        case WIFI_EVENT_STA_START:
+            break;
+        case WIFI_EVENT_STA_CONNECTED:
+            wifi->connected = true;
+            break;
+        case WIFI_EVENT_STA_DISCONNECTED:
+            wifi->ip.addr = 0;
+            wifi->connected = false;
+            publish_status(wifi->connected, true);
 
-                if (wifi->auto_connect_to_ap)
-                {
-                    esp_wifi_stop();
-                    wifi->connect();
-                }
+            if (wifi->auto_connect_to_ap) {
+                esp_wifi_stop();
+                wifi->connect();
             }
-            else if (event_id == WIFI_EVENT_AP_START)
-            {
-                wifi->ip.addr = 0xC0A80401; // 192.168.4.1
-                publish_status(true, true);
-            }
-            else if (event_id == WIFI_EVENT_AP_STOP)
-            {
-                wifi->ip.addr = 0;
-                Log::info("SoftAP", "AP stopped");
-                publish_status(false, true);
-            }
-            else if (event_id == WIFI_EVENT_AP_STACONNECTED)
-            {
-                auto data = reinterpret_cast<wifi_event_ap_staconnected_t*>(event_data);
-                Log::info("SoftAP", "Station connected. MAC: {}:{}:{}:{}:{}:{} join, AID={}",
-                                         data->mac[0],
-                                         data->mac[1],
-                                         data->mac[2],
-                                         data->mac[3],
-                                         data->mac[4],
-                                         data->mac[5],
-                                         data->aid);
-            }
-            else if (event_id == WIFI_EVENT_AP_STADISCONNECTED)
-            {
-                auto data = reinterpret_cast<wifi_event_ap_stadisconnected_t*>(event_data);
+            break;
+        case WIFI_EVENT_AP_START:
+            wifi->ip.addr = 0xC0A80401; // 192.168.4.1
+            publish_status(true, true);
+            break;
+        case WIFI_EVENT_AP_STOP:
+            wifi->ip.addr = 0;
+            Log::info("SoftAP", "AP stopped");
+            publish_status(false, true);
+            break;
+        case WIFI_EVENT_AP_STACONNECTED: {
+            auto data = reinterpret_cast<wifi_event_ap_staconnected_t*>(event_data);
+            Log::info("SoftAP", "Station connected. MAC: {}:{}:{}:{}:{}:{} join, AID={}",
+                      data->mac[0],
+                      data->mac[1],
+                      data->mac[2],
+                      data->mac[3],
+                      data->mac[4],
+                      data->mac[5],
+                      data->aid);
+        } break;
+        case WIFI_EVENT_AP_STADISCONNECTED: {
+            auto data = reinterpret_cast<wifi_event_ap_stadisconnected_t*>(event_data);
 
-                Log::info("SoftAP", "Station disconnected. MAC: {}:{}:{}:{}:{}:{} join, AID={}",
-                                         data->mac[0],
-                                         data->mac[1],
-                                         data->mac[2],
-                                         data->mac[3],
-                                         data->mac[4],
-                                         data->mac[5],
-                                         data->aid);
-            }
+            Log::info("SoftAP", "Station disconnected. MAC: {}:{}:{}:{}:{}:{} join, AID={}",
+                      data->mac[0],
+                      data->mac[1],
+                      data->mac[2],
+                      data->mac[3],
+                      data->mac[4],
+                      data->mac[5],
+                      data->aid);
+
+        } break;
         }
-        else if (event_base == IP_EVENT)
-        {
-            if (event_id == IP_EVENT_STA_GOT_IP
-                || event_id == IP_EVENT_GOT_IP6
-                || event_id == IP_EVENT_ETH_GOT_IP)
-            {
-                auto ip_changed = event_id == IP_EVENT_STA_GOT_IP ?
-                                  reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_changed : true;
-                publish_status(true, ip_changed);
-                wifi->ip.addr = reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_info.ip.addr;
-            }
-            else if (event_id == IP_EVENT_STA_LOST_IP)
-            {
-                wifi->ip.addr = 0;
-                publish_status(false, true);
-            }
+    } else if (event_base == IP_EVENT) {
+        if (event_id == IP_EVENT_STA_GOT_IP
+            || event_id == IP_EVENT_GOT_IP6
+            || event_id == IP_EVENT_ETH_GOT_IP) {
+            auto ip_changed = event_id == IP_EVENT_STA_GOT_IP ? reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_changed : true;
+            publish_status(true, ip_changed);
+            wifi->ip.addr = reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_info.ip.addr;
+        } else if (event_id == IP_EVENT_STA_LOST_IP) {
+            wifi->ip.addr = 0;
+            publish_status(false, true);
         }
     }
+}
 
-    void Wifi::close_if()
-    {
-        if (interface)
-        {
-            esp_netif_destroy(interface);
-            interface = nullptr;
-        }
-    }
+void
+Wifi::start_softap(uint8_t max_conn)
+{
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_wifi_init(&cfg);
 
-    std::string Wifi::get_mac_address()
-    {
-        std::stringstream mac;
+    wifi_config_t config{};
 
-        std::array<uint8_t, 6> m;
-        bool ret = get_local_mac_address(m);
+    copy_min_to_buffer(ssid.begin(), ssid.length(), config.ap.ssid);
+    copy_min_to_buffer(password.begin(), password.length(), config.ap.password);
 
-        if (ret)
-        {
-            for (const auto& v : m)
-            {
-                if (mac.tellp() > 0)
-                {
-                    mac << "_";
-                }
+    config.ap.max_connection = max_conn;
+    config.ap.authmode = password.empty() ? WIFI_AUTH_OPEN : WIFI_AUTH_WPA_WPA2_PSK;
 
-                mac << std::hex << static_cast<int>(v);
-            }
-        }
+    close_if();
+    interface = esp_netif_create_default_wifi_ap();
 
-        return mac.str();
-    }
+    esp_wifi_set_mode(WIFI_MODE_AP);
+    esp_wifi_set_config(ESP_IF_WIFI_AP, &config);
+    esp_wifi_start();
 
-    bool Wifi::get_local_mac_address(std::array<uint8_t, 6>& m)
-    {
-        wifi_mode_t mode;
-        esp_err_t err = esp_wifi_get_mode(&mode);
-
-        if (err == ESP_OK)
-        {
-            if (mode == WIFI_MODE_STA)
-            {
-                err = esp_wifi_get_mac(WIFI_IF_STA, m.data());
-            }
-            else if (mode == WIFI_MODE_AP)
-            {
-                err = esp_wifi_get_mac(WIFI_IF_AP, m.data());
-            }
-            else
-            {
-                err = ESP_FAIL;
-            }
-        }
-
-        if (err != ESP_OK)
-        {
-            Log::error("Wifi", "get_local_mac_address(): {}", esp_err_to_name(err));
-        }
-
-        return err == ESP_OK;
-    }
-
-    // attention: access to this function might have a threading issue.
-    // It should be called from the main thread only!
-    uint32_t Wifi::get_local_ip()
-    {
-        return ip.addr;
-    }
-
-    void Wifi::start_softap(uint8_t max_conn)
-    {
-        wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-        esp_wifi_init(&cfg);
-
-        wifi_config_t config{};
-
-        copy_min_to_buffer(ssid.begin(), ssid.length(), config.ap.ssid);
-        copy_min_to_buffer(password.begin(), password.length(), config.ap.password);
-
-        config.ap.max_connection = max_conn;
-        config.ap.authmode = password.empty() ? WIFI_AUTH_OPEN : WIFI_AUTH_WPA_WPA2_PSK;
-
-        close_if();
-        interface = esp_netif_create_default_wifi_ap();
-
-        esp_wifi_set_mode(WIFI_MODE_AP);
-        esp_wifi_set_config(ESP_IF_WIFI_AP, &config);
-        esp_wifi_start();
-
-        Log::info("SoftAP", "SSID: {}; Auth {}", ssid, (password.empty() ? "Open" : "WPA2/PSK"));
+    Log::info("SoftAP", "SSID: {}; Auth {}", ssid, (password.empty() ? "Open" : "WPA2/PSK"));
 
 #ifndef ESP_PLATFORM
 
-        // Assume network is available when running under POSIX system.
-        publish_status(true, true);
+    // Assume network is available when running under POSIX system.
+    publish_status(true, true);
 #endif
-    }
+}
 
-    void Wifi::publish_status(bool connected, bool ip_changed)
-    {
-        network::NetworkStatus status(connected
-                                      ? network::NetworkEvent::GOT_IP : network::NetworkEvent::DISCONNECTED,
-                                      ip_changed);
-        core::ipc::Publisher<network::NetworkStatus>::publish(status);
-    }
+void
+Wifi::publish_status(bool connected, bool ip_changed)
+{
+    network::NetworkStatus status(connected
+                                      ? network::NetworkEvent::GOT_IP
+                                      : network::NetworkEvent::DISCONNECTED,
+                                  ip_changed);
+    core::ipc::Publisher<network::NetworkStatus>::publish(status);
+}
 }

--- a/lib/smooth/include/smooth/core/Application.h
+++ b/lib/smooth/include/smooth/core/Application.h
@@ -61,10 +61,7 @@ namespace smooth::core
 
             network::Wifi& get_wifi()
             {
-                return wifi;
+                return network::get_wifi();
             }
-
-        private:
-            network::Wifi wifi{};
     };
 }

--- a/lib/smooth/include/smooth/core/network/Ethernet.h
+++ b/lib/smooth/include/smooth/core/network/Ethernet.h
@@ -28,38 +28,39 @@ limitations under the License.
 #include "smooth/core/network/NetworkInterface.h"
 
 namespace smooth::core::network {
+    class Ethernet : public NetworkInterface
+    {
+        public:
+            Ethernet(std::string&& string = "Ethernet");
 
-class Ethernet : public NetworkInterface {
-public:
-    Ethernet(std::string&& string = "Ethernet");
+            Ethernet(const Ethernet&) = delete;
 
-    Ethernet(const Ethernet&) = delete;
+            Ethernet(Ethernet&&) = delete;
 
-    Ethernet(Ethernet&&) = delete;
+            Ethernet& operator=(const Ethernet&) = delete;
 
-    Ethernet& operator=(const Ethernet&) = delete;
+            Ethernet& operator=(Ethernet&&) = delete;
 
-    Ethernet& operator=(Ethernet&&) = delete;
+            ~Ethernet();
 
-    ~Ethernet();
+            void start();
 
-    void start();
+            [[nodiscard]] bool is_connected() const;
 
-    [[nodiscard]] bool is_connected() const;
+            static void eth_event_callback(void* event_handler_arg,
+                                           esp_event_base_t event_base,
+                                           int32_t event_id,
+                                           void* event_data);
 
-    static void eth_event_callback(void* event_handler_arg,
-                                   esp_event_base_t event_base,
-                                   int32_t event_id,
-                                   void* event_data);
+        private:
+            void connect() const;
 
-private:
-    void connect() const;
-    static void publish_status(bool connected, bool ip_changed);
+            static void publish_status(bool connected, bool ip_changed);
 
-    esp_event_handler_instance_t instance_eth_event{};
-    esp_event_handler_instance_t instance_ip_event{};
-    esp_eth_mac_t* mac{nullptr};
-    esp_eth_phy_t* phy{nullptr};
-    esp_eth_handle_t eth_handle{nullptr};
-};
+            esp_event_handler_instance_t instance_eth_event{};
+            esp_event_handler_instance_t instance_ip_event{};
+            esp_eth_mac_t* mac{ nullptr };
+            esp_eth_phy_t* phy{ nullptr };
+            esp_eth_handle_t eth_handle{ nullptr };
+    };
 }

--- a/lib/smooth/include/smooth/core/network/Ethernet.h
+++ b/lib/smooth/include/smooth/core/network/Ethernet.h
@@ -23,6 +23,7 @@ limitations under the License.
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <esp_eth.h>
+#include <esp_event_base.h>
 #pragma GCC diagnostic pop
 #include "smooth/core/ipc/IEventListener.h"
 #include "smooth/core/network/NetworkInterface.h"

--- a/lib/smooth/include/smooth/core/network/Ethernet.h
+++ b/lib/smooth/include/smooth/core/network/Ethernet.h
@@ -28,10 +28,10 @@ limitations under the License.
 #include "smooth/core/network/NetworkInterface.h"
 
 namespace smooth::core::network {
-/// Ethernet management class
+
 class Ethernet : public NetworkInterface {
 public:
-    Ethernet(std::string name = "Ethernet");
+    Ethernet(std::string&& string = "Ethernet");
 
     Ethernet(const Ethernet&) = delete;
 
@@ -43,13 +43,8 @@ public:
 
     ~Ethernet();
 
-    /// Calls do_init and logs errors that occur
-    /// \return true on sucess
-    bool init();
-    void deinit();
+    void start();
 
-    /// Returns a value indicating of currently connected to the access point.
-    /// \return
     [[nodiscard]] bool is_connected() const;
 
     static void eth_event_callback(void* event_handler_arg,
@@ -59,16 +54,10 @@ public:
 
 private:
     void connect() const;
-
-    esp_err_t do_init();
-
-    void close_if();
-
     static void publish_status(bool connected, bool ip_changed);
 
     esp_event_handler_instance_t instance_eth_event{};
     esp_event_handler_instance_t instance_ip_event{};
-    esp_netif_t* interface{nullptr};
     esp_eth_mac_t* mac{nullptr};
     esp_eth_phy_t* phy{nullptr};
     esp_eth_handle_t eth_handle{nullptr};

--- a/lib/smooth/include/smooth/core/network/Ethernet.h
+++ b/lib/smooth/include/smooth/core/network/Ethernet.h
@@ -1,0 +1,76 @@
+/*
+Smooth - A C++ framework for embedded programming on top of Espressif's ESP-IDF
+Copyright 2019 Per Malmberg (https://gitbub.com/PerMalmberg)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <array>
+#include <string>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#include <esp_eth.h>
+#pragma GCC diagnostic pop
+#include "smooth/core/ipc/IEventListener.h"
+#include "smooth/core/network/NetworkInterface.h"
+
+namespace smooth::core::network {
+/// Ethernet management class
+class Ethernet : public NetworkInterface {
+public:
+    Ethernet(std::string name = "Ethernet");
+
+    Ethernet(const Ethernet&) = delete;
+
+    Ethernet(Ethernet&&) = delete;
+
+    Ethernet& operator=(const Ethernet&) = delete;
+
+    Ethernet& operator=(Ethernet&&) = delete;
+
+    ~Ethernet();
+
+    /// Calls do_init and logs errors that occur
+    /// \return true on sucess
+    bool init();
+    void deinit();
+
+    /// Returns a value indicating of currently connected to the access point.
+    /// \return
+    [[nodiscard]] bool is_connected() const;
+
+    static void eth_event_callback(void* event_handler_arg,
+                                   esp_event_base_t event_base,
+                                   int32_t event_id,
+                                   void* event_data);
+
+private:
+    void connect() const;
+
+    esp_err_t do_init();
+
+    void close_if();
+
+    static void publish_status(bool connected, bool ip_changed);
+
+    esp_event_handler_instance_t instance_eth_event{};
+    esp_event_handler_instance_t instance_ip_event{};
+    esp_netif_t* interface{nullptr};
+    esp_eth_mac_t* mac{nullptr};
+    esp_eth_phy_t* phy{nullptr};
+    esp_eth_handle_t eth_handle{nullptr};
+};
+}

--- a/lib/smooth/include/smooth/core/network/NetworkInterface.h
+++ b/lib/smooth/include/smooth/core/network/NetworkInterface.h
@@ -17,14 +17,18 @@ limitations under the License.
 
 #pragma once
 #include <array>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <esp_netif.h>
+#pragma GCC diagnostic pop
 #include <string>
 
 namespace smooth::core::network {
-/// Ethernet management class
+
 class NetworkInterface {
 public:
-    NetworkInterface(std::string name);
+    NetworkInterface(std::string&& name);
 
     NetworkInterface(const NetworkInterface&) = delete;
 
@@ -36,12 +40,8 @@ public:
 
     virtual ~NetworkInterface();
 
-    /// Sets the hostname
-    /// \param name The name
     void set_host_name(const std::string& name);
 
-    /// Returns a value indicating of currently connected to the access point.
-    /// \return
     [[nodiscard]] bool is_connected() const;
 
     [[nodiscard]] std::string get_mac_address() const;
@@ -50,13 +50,16 @@ public:
 
     bool get_local_mac_address(std::array<uint8_t, 6>& m) const;
 
-    void close_if();
-
 protected:
+    void apply_host_name();
+
     esp_ip4_addr ip = {0};
     bool connected = false;
     esp_netif_t* interface{nullptr};
     static uint8_t interface_count;
     std::string interface_name;
+    // esp_netif_set_hostname only copies a const char* pointer, so we need to keep this allocated here
+    // max 32 characters
+    char host_name[33] = "";
 };
 }

--- a/lib/smooth/include/smooth/core/network/NetworkInterface.h
+++ b/lib/smooth/include/smooth/core/network/NetworkInterface.h
@@ -1,0 +1,62 @@
+/*
+Smooth - A C++ framework for embedded programming on top of Espressif's ESP-IDF
+Copyright 2019 Per Malmberg (https://gitbub.com/PerMalmberg)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+#include <array>
+#include <esp_netif.h>
+#include <string>
+
+namespace smooth::core::network {
+/// Ethernet management class
+class NetworkInterface {
+public:
+    NetworkInterface(std::string name);
+
+    NetworkInterface(const NetworkInterface&) = delete;
+
+    NetworkInterface(NetworkInterface&&) = delete;
+
+    NetworkInterface& operator=(const NetworkInterface&) = delete;
+
+    NetworkInterface& operator=(NetworkInterface&&) = delete;
+
+    virtual ~NetworkInterface();
+
+    /// Sets the hostname
+    /// \param name The name
+    void set_host_name(const std::string& name);
+
+    /// Returns a value indicating of currently connected to the access point.
+    /// \return
+    [[nodiscard]] bool is_connected() const;
+
+    [[nodiscard]] std::string get_mac_address() const;
+
+    [[nodiscard]] uint32_t get_local_ip() const;
+
+    bool get_local_mac_address(std::array<uint8_t, 6>& m) const;
+
+    void close_if();
+
+protected:
+    esp_ip4_addr ip = {0};
+    bool connected = false;
+    esp_netif_t* interface{nullptr};
+    static uint8_t interface_count;
+    std::string interface_name;
+};
+}

--- a/lib/smooth/include/smooth/core/network/NetworkInterface.h
+++ b/lib/smooth/include/smooth/core/network/NetworkInterface.h
@@ -25,41 +25,42 @@ limitations under the License.
 #include <string>
 
 namespace smooth::core::network {
+    class NetworkInterface
+    {
+        public:
+            NetworkInterface(std::string&& name);
 
-class NetworkInterface {
-public:
-    NetworkInterface(std::string&& name);
+            NetworkInterface(const NetworkInterface&) = delete;
 
-    NetworkInterface(const NetworkInterface&) = delete;
+            NetworkInterface(NetworkInterface&&) = delete;
 
-    NetworkInterface(NetworkInterface&&) = delete;
+            NetworkInterface& operator=(const NetworkInterface&) = delete;
 
-    NetworkInterface& operator=(const NetworkInterface&) = delete;
+            NetworkInterface& operator=(NetworkInterface&&) = delete;
 
-    NetworkInterface& operator=(NetworkInterface&&) = delete;
+            virtual ~NetworkInterface();
 
-    virtual ~NetworkInterface();
+            void set_host_name(const std::string& name);
 
-    void set_host_name(const std::string& name);
+            [[nodiscard]] bool is_connected() const;
 
-    [[nodiscard]] bool is_connected() const;
+            [[nodiscard]] std::string get_mac_address() const;
 
-    [[nodiscard]] std::string get_mac_address() const;
+            [[nodiscard]] uint32_t get_local_ip() const;
 
-    [[nodiscard]] uint32_t get_local_ip() const;
+            bool get_local_mac_address(std::array<uint8_t, 6>& m) const;
 
-    bool get_local_mac_address(std::array<uint8_t, 6>& m) const;
+        protected:
+            void apply_host_name();
 
-protected:
-    void apply_host_name();
+            esp_ip4_addr ip = { 0 };
+            bool connected = false;
+            esp_netif_t* interface{ nullptr };
+            static uint8_t interface_count;
+            std::string interface_name;
 
-    esp_ip4_addr ip = {0};
-    bool connected = false;
-    esp_netif_t* interface{nullptr};
-    static uint8_t interface_count;
-    std::string interface_name;
-    // esp_netif_set_hostname only copies a const char* pointer, so we need to keep this allocated here
-    // max 32 characters
-    char host_name[33] = "";
-};
+            // esp_netif_set_hostname only copies a const char* pointer, so we need to keep this allocated here
+            // max 32 characters
+            char host_name[33] = "";
+    };
 }

--- a/lib/smooth/include/smooth/core/network/Wifi.h
+++ b/lib/smooth/include/smooth/core/network/Wifi.h
@@ -88,4 +88,7 @@ namespace smooth::core::network {
             esp_event_handler_instance_t instance_wifi_event{};
             esp_event_handler_instance_t instance_ip_event{};
     };
+
+    Wifi&
+    get_wifi();
 }

--- a/lib/smooth/include/smooth/core/network/Wifi.h
+++ b/lib/smooth/include/smooth/core/network/Wifi.h
@@ -26,64 +26,66 @@ limitations under the License.
 
 namespace smooth::core::network {
 /// Wifi management class
-class Wifi : public NetworkInterface {
-public:
-    Wifi(std::string&& name = "WiFi");
-
-    Wifi(const Wifi&) = delete;
-
-    Wifi(Wifi&&) = delete;
-
-    Wifi& operator=(const Wifi&) = delete;
-
-    Wifi& operator=(Wifi&&) = delete;
-
-    ~Wifi();
-
-    /// Sets the credentials for the Wifi network
-    /// \param wifi_ssid The SSID
-    /// \param wifi_password The password
-    void set_ap_credentials(const std::string& wifi_ssid, const std::string& wifi_password);
-
-    /// Enables, disables auto reconnect on loss of Wifi connection.
-    /// \param auto_connect
-    void set_auto_connect(bool auto_connect);
-
-    /// Initiates the connection to the AP.
-    void connect_to_ap();
-
-    /// Returns a value indicating of currently connected to the access point.
-    /// \return
-    [[nodiscard]] bool is_connected_to_ap() const;
-
-    /// Returns a value indicating if the required settings are set.
-    /// \return true or false.
-    [[nodiscard]] bool is_configured() const
+    class Wifi : public NetworkInterface
     {
-        return ssid.length() > 0 && password.length() > 0;
-    }
+        public:
+            Wifi(std::string&& name = "WiFi");
 
-    static void wifi_event_callback(void* event_handler_arg,
-                                    esp_event_base_t event_base,
-                                    int32_t event_id,
-                                    void* event_data);
+            Wifi(const Wifi&) = delete;
 
-    /// Start providing an access point
-    /// \param max_conn maximum number of clients to connect to this AP
-    void start_softap(uint8_t max_conn = 1);
+            Wifi(Wifi&&) = delete;
 
-private:
-    void connect() const;
-    void close_if();
+            Wifi& operator=(const Wifi&) = delete;
 
-    static void publish_status(bool connected, bool ip_changed);
+            Wifi& operator=(Wifi&&) = delete;
 
-    bool auto_connect_to_ap = false;
-    std::string ssid{};
-    std::string password{};
+            ~Wifi();
 
-    esp_netif_t* interface{nullptr};
-    esp_event_handler_instance_t instance_wifi_event{};
-    esp_event_handler_instance_t instance_ip_event{};
-};
+            /// Sets the credentials for the Wifi network
+            /// \param wifi_ssid The SSID
+            /// \param wifi_password The password
+            void set_ap_credentials(const std::string& wifi_ssid, const std::string& wifi_password);
+
+            /// Enables, disables auto reconnect on loss of Wifi connection.
+            /// \param auto_connect
+            void set_auto_connect(bool auto_connect);
+
+            /// Initiates the connection to the AP.
+            void connect_to_ap();
+
+            /// Returns a value indicating of currently connected to the access point.
+            /// \return
+            [[nodiscard]] bool is_connected_to_ap() const;
+
+            /// Returns a value indicating if the required settings are set.
+            /// \return true or false.
+            [[nodiscard]] bool is_configured() const
+            {
+                return ssid.length() > 0 && password.length() > 0;
+            }
+
+            static void wifi_event_callback(void* event_handler_arg,
+                                            esp_event_base_t event_base,
+                                            int32_t event_id,
+                                            void* event_data);
+
+            /// Start providing an access point
+            /// \param max_conn maximum number of clients to connect to this AP
+            void start_softap(uint8_t max_conn = 1);
+
+        private:
+            void connect() const;
+
+            void close_if();
+
+            static void publish_status(bool connected, bool ip_changed);
+
+            bool auto_connect_to_ap = false;
+            std::string ssid{};
+            std::string password{};
+
+            esp_netif_t* interface{ nullptr };
+            esp_event_handler_instance_t instance_wifi_event{};
+            esp_event_handler_instance_t instance_ip_event{};
+    };
 }

--- a/lib/smooth/include/smooth/core/network/Wifi.h
+++ b/lib/smooth/include/smooth/core/network/Wifi.h
@@ -22,14 +22,13 @@ limitations under the License.
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <esp_wifi.h>
 #pragma GCC diagnostic pop
-// #include "smooth/core/ipc/IEventListener.h"
 #include "smooth/core/network/NetworkInterface.h"
 
 namespace smooth::core::network {
 /// Wifi management class
 class Wifi : public NetworkInterface {
 public:
-    Wifi(std::string name = "WiFi");
+    Wifi(std::string&& name = "WiFi");
 
     Wifi(const Wifi&) = delete;
 
@@ -75,6 +74,7 @@ public:
 
 private:
     void connect() const;
+    void close_if();
 
     static void publish_status(bool connected, bool ip_changed);
 

--- a/mock-idf/components/esp_eth/include/esp_eth.h
+++ b/mock-idf/components/esp_eth/include/esp_eth.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "esp_eth_com.h"
+#include "esp_eth_mac.h"
+#include "esp_eth_phy.h"
+#include <esp_err.h>
+
+#define CONFIG_SMOOTH_ETH_PHY_MOCK 1
+#define CONFIG_SMOOTH_USE_INTERNAL_ETHERNET 1
+#define CONFIG_SMOOTH_ETH_MDC_GPIO 23
+#define CONFIG_SMOOTH_ETH_MDIO_GPIO 18
+#define CONFIG_SMOOTH_ETH_PHY_RST_GPIO 5
+#define CONFIG_SMOOTH_ETH_PHY_ADDR 0
+
+typedef void* esp_eth_handle_t;
+
+typedef struct {
+    esp_eth_mac_t* mac;
+    esp_eth_phy_t* phy;
+    uint32_t check_link_period_ms;
+    esp_err_t (*stack_input)(esp_eth_handle_t eth_handle, uint8_t* buffer, uint32_t length, void* priv);
+    esp_err_t (*on_lowlevel_init_done)(esp_eth_handle_t eth_handle);
+    esp_err_t (*on_lowlevel_deinit_done)(esp_eth_handle_t eth_handle);
+} esp_eth_config_t;
+
+#define ESP_NETIF_DEFAULT_ETH() {}
+
+#define ETH_DEFAULT_CONFIG(emac, ephy)   \
+    {                                    \
+        .mac = emac,                     \
+        .phy = ephy,                     \
+        .check_link_period_ms = 2000,    \
+        .stack_input = NULL,             \
+        .on_lowlevel_init_done = NULL,   \
+        .on_lowlevel_deinit_done = NULL, \
+    }
+
+inline esp_err_t esp_eth_driver_install(const esp_eth_config_t* /*config*/, esp_eth_handle_t* /*out_hdl*/){ return ESP_OK; };
+inline esp_err_t esp_eth_driver_uninstall(esp_eth_handle_t /*hdl*/){ return ESP_OK; };
+inline esp_err_t esp_eth_start(esp_eth_handle_t /*hdl*/){ return ESP_OK; };
+inline esp_err_t esp_eth_stop(esp_eth_handle_t /*hdl*/){ return ESP_OK; };
+inline esp_err_t esp_eth_update_input_path(
+    esp_eth_handle_t /*hdl*/,
+    esp_err_t (* /*stack_input*/)(esp_eth_handle_t hdl, uint8_t* buffer, uint32_t length, void* priv),     void* /*priv*/)
+{
+    return ESP_OK; 
+};
+inline esp_err_t esp_eth_transmit(esp_eth_handle_t /*hdl*/, void* /*buf*/, uint32_t /*length*/){ return ESP_OK; };
+inline esp_err_t esp_eth_receive(esp_eth_handle_t /*hdl*/, uint8_t* /*buf*/, uint32_t* /*length*/){ return ESP_OK; };
+inline esp_err_t esp_eth_ioctl(esp_eth_handle_t /*hdl*/, esp_eth_io_cmd_t /*cmd*/, void* /*data*/){ return ESP_OK; };
+inline esp_err_t esp_eth_increase_reference(esp_eth_handle_t /*hdl*/){ return ESP_OK; };
+inline esp_err_t esp_eth_decrease_reference(esp_eth_handle_t /*hdl*/){ return ESP_OK; };

--- a/mock-idf/components/esp_eth/include/esp_eth_com.h
+++ b/mock-idf/components/esp_eth/include/esp_eth_com.h
@@ -1,0 +1,225 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <esp_err.h>
+#include <esp_event_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Maximum Ethernet payload size
+ *
+ */
+#define ETH_MAX_PAYLOAD_LEN (1500)
+
+/**
+ * @brief Minimum Ethernet payload size
+ *
+ */
+#define ETH_MIN_PAYLOAD_LEN (46)
+
+/**
+ * @brief Ethernet frame header size: Dest addr(6 Bytes) + Src addr(6 Bytes) + length/type(2 Bytes)
+ *
+ */
+#define ETH_HEADER_LEN (14)
+
+/**
+ * @brief Ethernet frame CRC length
+ *
+ */
+#define ETH_CRC_LEN (4)
+
+/**
+ * @brief Optional 802.1q VLAN Tag length
+ *
+ */
+#define ETH_VLAN_TAG_LEN (4)
+
+/**
+ * @brief Jumbo frame payload size
+ *
+ */
+#define ETH_JUMBO_FRAME_PAYLOAD_LEN (9000)
+
+/**
+ * @brief Maximum frame size (1522 Bytes)
+ *
+ */
+#define ETH_MAX_PACKET_SIZE (ETH_HEADER_LEN + ETH_VLAN_TAG_LEN + ETH_MAX_PAYLOAD_LEN + ETH_CRC_LEN)
+
+/**
+ * @brief Minimum frame size (64 Bytes)
+ *
+ */
+#define ETH_MIN_PACKET_SIZE (ETH_HEADER_LEN + ETH_MIN_PAYLOAD_LEN + ETH_CRC_LEN)
+
+/**
+* @brief Ethernet driver state
+*
+*/
+typedef enum {
+    ETH_STATE_LLINIT, /*!< Lowlevel init done */
+    ETH_STATE_DEINIT, /*!< Deinit done */
+    ETH_STATE_LINK,   /*!< Link status changed */
+    ETH_STATE_SPEED,  /*!< Speed updated */
+    ETH_STATE_DUPLEX, /*!< Duplex updated */
+} esp_eth_state_t;
+
+/**
+* @brief Command list for ioctl API
+*
+*/
+typedef enum {
+    ETH_CMD_G_MAC_ADDR,    /*!< Get MAC address */
+    ETH_CMD_S_MAC_ADDR,    /*!< Set MAC address */
+    ETH_CMD_G_PHY_ADDR,    /*!< Get PHY address */
+    ETH_CMD_S_PHY_ADDR,    /*!< Set PHY address */
+    ETH_CMD_G_SPEED,       /*!< Get Speed */
+    ETH_CMD_S_PROMISCUOUS, /*!< Set promiscuous mode */
+} esp_eth_io_cmd_t;
+
+/**
+* @brief Ethernet link status
+*
+*/
+typedef enum {
+    ETH_LINK_UP,  /*!< Ethernet link is up */
+    ETH_LINK_DOWN /*!< Ethernet link is down */
+} eth_link_t;
+
+/**
+* @brief Ethernet speed
+*
+*/
+typedef enum {
+    ETH_SPEED_10M, /*!< Ethernet speed is 10Mbps */
+    ETH_SPEED_100M /*!< Ethernet speed is 100Mbps */
+} eth_speed_t;
+
+/**
+* @brief Ethernet duplex mode
+*
+*/
+typedef enum {
+    ETH_DUPLEX_HALF, /*!< Ethernet is in half duplex */
+    ETH_DUPLEX_FULL  /*!< Ethernet is in full duplex */
+} eth_duplex_t;
+
+/**
+* @brief Ethernet mediator
+*
+*/
+typedef struct esp_eth_mediator_s esp_eth_mediator_t;
+
+/**
+* @brief Ethernet mediator
+*
+*/
+struct esp_eth_mediator_s {
+    /**
+    * @brief Read PHY register
+    *
+    * @param[in] eth: mediator of Ethernet driver
+    * @param[in] phy_addr: PHY Chip address (0~31)
+    * @param[in] phy_reg: PHY register index code
+    * @param[out] reg_value: PHY register value
+    *
+    * @return
+    *       - ESP_OK: read PHY register successfully
+    *       - ESP_FAIL: read PHY register failed because some error occurred
+    *
+    */
+    esp_err_t (*phy_reg_read)(esp_eth_mediator_t* eth, uint32_t phy_addr, uint32_t phy_reg, uint32_t* reg_value);
+
+    /**
+    * @brief Write PHY register
+    *
+    * @param[in] eth: mediator of Ethernet driver
+    * @param[in] phy_addr: PHY Chip address (0~31)
+    * @param[in] phy_reg: PHY register index code
+    * @param[in] reg_value: PHY register value
+    *
+    * @return
+    *       - ESP_OK: write PHY register successfully
+    *       - ESP_FAIL: write PHY register failed because some error occurred
+    */
+    esp_err_t (*phy_reg_write)(esp_eth_mediator_t* eth, uint32_t phy_addr, uint32_t phy_reg, uint32_t reg_value);
+
+    /**
+    * @brief Deliver packet to upper stack
+    *
+    * @param[in] eth: mediator of Ethernet driver
+    * @param[in] buffer: packet buffer
+    * @param[in] length: length of the packet
+    *
+    * @return
+    *       - ESP_OK: deliver packet to upper stack successfully
+    *       - ESP_FAIL: deliver packet failed because some error occurred
+    *
+    */
+    esp_err_t (*stack_input)(esp_eth_mediator_t* eth, uint8_t* buffer, uint32_t length);
+
+    /**
+    * @brief Callback on Ethernet state changed
+    *
+    * @param[in] eth: mediator of Ethernet driver
+    * @param[in] state: new state
+    * @param[in] args: optional argument for the new state
+    *
+    * @return
+    *       - ESP_OK: process the new state successfully
+    *       - ESP_FAIL: process the new state failed because some error occurred
+    *
+    */
+    esp_err_t (*on_state_changed)(esp_eth_mediator_t* eth, esp_eth_state_t state, void* args);
+};
+
+/**
+* @brief Ethernet event declarations
+*
+*/
+typedef enum {
+    ETHERNET_EVENT_START,        /*!< Ethernet driver start */
+    ETHERNET_EVENT_STOP,         /*!< Ethernet driver stop */
+    ETHERNET_EVENT_CONNECTED,    /*!< Ethernet got a valid link */
+    ETHERNET_EVENT_DISCONNECTED, /*!< Ethernet lost a valid link */
+} eth_event_t;
+
+/**
+* @brief Ethernet event base declaration
+*
+*/
+ESP_EVENT_DECLARE_BASE(ETH_EVENT);
+
+/**
+* @brief Detect PHY address
+*
+* @param[in] eth: mediator of Ethernet driver
+* @param[out] detected_addr: a valid address after detection
+* @return
+*       - ESP_OK: detect phy address successfully
+*       - ESP_ERR_INVALID_ARG: invalid parameter
+*       - ESP_ERR_NOT_FOUND: can't detect any PHY device
+*       - ESP_FAIL: detect phy address failed because some error occurred
+*/
+esp_err_t
+esp_eth_detect_phy_addr(esp_eth_mediator_t* eth, uint32_t* detected_addr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/mock-idf/components/esp_eth/include/esp_eth_mac.h
+++ b/mock-idf/components/esp_eth/include/esp_eth_mac.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "esp_eth_com.h"
+#include <stdbool.h>
+
+typedef struct esp_eth_mac_s esp_eth_mac_t;
+
+struct esp_eth_mac_s {
+    esp_err_t (*set_mediator)(esp_eth_mac_t* mac, esp_eth_mediator_t* eth);
+    esp_err_t (*init)(esp_eth_mac_t* mac);
+    esp_err_t (*deinit)(esp_eth_mac_t* mac);
+    esp_err_t (*start)(esp_eth_mac_t* mac);
+    esp_err_t (*stop)(esp_eth_mac_t* mac);
+    esp_err_t (*transmit)(esp_eth_mac_t* mac, uint8_t* buf, uint32_t length);
+    esp_err_t (*receive)(esp_eth_mac_t* mac, uint8_t* buf, uint32_t* length);
+    esp_err_t (*read_phy_reg)(esp_eth_mac_t* mac, uint32_t phy_addr, uint32_t phy_reg, uint32_t* reg_value);
+    esp_err_t (*write_phy_reg)(esp_eth_mac_t* mac, uint32_t phy_addr, uint32_t phy_reg, uint32_t reg_value);
+    esp_err_t (*set_addr)(esp_eth_mac_t* mac, uint8_t* addr);
+    esp_err_t (*get_addr)(esp_eth_mac_t* mac, uint8_t* addr);
+    esp_err_t (*set_speed)(esp_eth_mac_t* mac, eth_speed_t speed);
+    esp_err_t (*set_duplex)(esp_eth_mac_t* mac, eth_duplex_t duplex);
+    esp_err_t (*set_link)(esp_eth_mac_t* mac, eth_link_t link);
+    esp_err_t (*set_promiscuous)(esp_eth_mac_t* mac, bool enable);
+    esp_err_t (*del)(esp_eth_mac_t* mac);
+};
+
+/**
+* @brief Configuration of Ethernet MAC object
+*
+*/
+typedef struct {
+    uint32_t sw_reset_timeout_ms; /*!< Software reset timeout value (Unit: ms) */
+    uint32_t rx_task_stack_size;  /*!< Stack size of the receive task */
+    uint32_t rx_task_prio;        /*!< Priority of the receive task */
+    int smi_mdc_gpio_num;         /*!< SMI MDC GPIO number */
+    int smi_mdio_gpio_num;        /*!< SMI MDIO GPIO number */
+    uint32_t flags;               /*!< Flags that specify extra capability for mac driver */
+} eth_mac_config_t;
+
+#define ETH_MAC_FLAG_WORK_WITH_CACHE_DISABLE (1 << 0) /*!< MAC driver can work when cache is disabled */
+#define ETH_MAC_FLAG_PIN_TO_CORE (1 << 1)             /*!< Pin MAC task to the CPU core where driver installation happened */
+
+/**
+ * @brief Default configuration for Ethernet MAC object
+ *
+ */
+#define ETH_MAC_DEFAULT_CONFIG()    \
+    {                               \
+        .sw_reset_timeout_ms = 100, \
+        .rx_task_stack_size = 4096, \
+        .rx_task_prio = 15,         \
+        .smi_mdc_gpio_num = 23,     \
+        .smi_mdio_gpio_num = 18,    \
+        .flags = 0,                 \
+    }
+
+/**
+* @brief Create ESP32 Ethernet MAC instance
+*
+* @param config: Ethernet MAC configuration
+*
+* @return
+*      - instance: create MAC instance successfully
+*      - NULL: create MAC instance failed because some error occurred
+*/
+inline esp_eth_mac_t*
+esp_eth_mac_new_esp32(const eth_mac_config_t* /*config*/)
+{
+    return nullptr;
+}

--- a/mock-idf/components/esp_eth/include/esp_eth_netif_glue.h
+++ b/mock-idf/components/esp_eth/include/esp_eth_netif_glue.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <esp_eth.h>
+
+inline void* esp_eth_new_netif_glue(esp_eth_handle_t /*eth_hdl*/){ return ESP_OK; }
+inline esp_err_t esp_eth_del_netif_glue(void* /*glue*/){ return ESP_OK; }
+inline esp_err_t esp_eth_set_default_handlers(void* /*esp_netif*/){ return ESP_OK; }
+inline esp_err_t esp_eth_clear_default_handlers(void* /*esp_netif*/){ return ESP_OK; }

--- a/mock-idf/components/esp_eth/include/esp_eth_phy.h
+++ b/mock-idf/components/esp_eth/include/esp_eth_phy.h
@@ -1,0 +1,198 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "esp_eth_com.h"
+#include <stdbool.h>
+
+#define ESP_ETH_PHY_ADDR_AUTO (-1)
+
+/**
+* @brief Ethernet PHY
+*
+*/
+typedef struct esp_eth_phy_s esp_eth_phy_t;
+
+/**
+* @brief Ethernet PHY
+*
+*/
+struct esp_eth_phy_s {
+    /**
+    * @brief Set mediator for PHY
+    *
+    * @param[in] phy: Ethernet PHY instance
+    * @param[in] mediator: mediator of Ethernet driver
+    *
+    * @return
+    *      - ESP_OK: set mediator for Ethernet PHY instance successfully
+    *      - ESP_ERR_INVALID_ARG: set mediator for Ethernet PHY instance failed because of some invalid arguments
+    *
+    */
+    esp_err_t (*set_mediator)(esp_eth_phy_t* phy, esp_eth_mediator_t* mediator);
+
+    /**
+    * @brief Software Reset Ethernet PHY
+    *
+    * @param[in] phy: Ethernet PHY instance
+    *
+    * @return
+    *      - ESP_OK: reset Ethernet PHY successfully
+    *      - ESP_FAIL: reset Ethernet PHY failed because some error occurred
+    *
+    */
+    esp_err_t (*reset)(esp_eth_phy_t* phy);
+
+    /**
+    * @brief Hardware Reset Ethernet PHY
+    *
+    * @note Hardware reset is mostly done by pull down and up PHY's nRST pin
+    *
+    * @param[in] phy: Ethernet PHY instance
+    *
+    * @return
+    *      - ESP_OK: reset Ethernet PHY successfully
+    *      - ESP_FAIL: reset Ethernet PHY failed because some error occurred
+    *
+    */
+    esp_err_t (*reset_hw)(esp_eth_phy_t* phy);
+
+    /**
+    * @brief Initialize Ethernet PHY
+    *
+    * @param[in] phy: Ethernet PHY instance
+    *
+    * @return
+    *      - ESP_OK: initialize Ethernet PHY successfully
+    *      - ESP_FAIL: initialize Ethernet PHY failed because some error occurred
+    *
+    */
+    esp_err_t (*init)(esp_eth_phy_t* phy);
+
+    /**
+    * @brief Deinitialize Ethernet PHY
+    *
+    * @param[in] phyL Ethernet PHY instance
+    *
+    * @return
+    *      - ESP_OK: deinitialize Ethernet PHY successfully
+    *      - ESP_FAIL: deinitialize Ethernet PHY failed because some error occurred
+    *
+    */
+    esp_err_t (*deinit)(esp_eth_phy_t* phy);
+
+    /**
+    * @brief Start auto negotiation
+    *
+    * @param[in] phy: Ethernet PHY instance
+    *
+    * @return
+    *      - ESP_OK: restart auto negotiation successfully
+    *      - ESP_FAIL: restart auto negotiation failed because some error occurred
+    *
+    */
+    esp_err_t (*negotiate)(esp_eth_phy_t* phy);
+
+    /**
+    * @brief Get Ethernet PHY link status
+    *
+    * @param[in] phy: Ethernet PHY instance
+    *
+    * @return
+    *      - ESP_OK: get Ethernet PHY link status successfully
+    *      - ESP_FAIL: get Ethernet PHY link status failed because some error occurred
+    *
+    */
+    esp_err_t (*get_link)(esp_eth_phy_t* phy);
+
+    /**
+    * @brief Power control of Ethernet PHY
+    *
+    * @param[in] phy: Ethernet PHY instance
+    * @param[in] enable: set true to power on Ethernet PHY; ser false to power off Ethernet PHY
+    *
+    * @return
+    *      - ESP_OK: control Ethernet PHY power successfully
+    *      - ESP_FAIL: control Ethernet PHY power failed because some error occurred
+    *
+    */
+    esp_err_t (*pwrctl)(esp_eth_phy_t* phy, bool enable);
+
+    /**
+    * @brief Set PHY chip address
+    *
+    * @param[in] phy: Ethernet PHY instance
+    * @param[in] addr: PHY chip address
+    *
+    * @return
+    *      - ESP_OK: set Ethernet PHY address successfully
+    *      - ESP_FAIL: set Ethernet PHY address failed because some error occurred
+    *
+    */
+    esp_err_t (*set_addr)(esp_eth_phy_t* phy, uint32_t addr);
+
+    /**
+    * @brief Get PHY chip address
+    *
+    * @param[in] phy: Ethernet PHY instance
+    * @param[out] addr: PHY chip address
+    *
+    * @return
+    *      - ESP_OK: get Ethernet PHY address successfully
+    *      - ESP_ERR_INVALID_ARG: get Ethernet PHY address failed because of invalid argument
+    *
+    */
+    esp_err_t (*get_addr)(esp_eth_phy_t* phy, uint32_t* addr);
+
+    /**
+    * @brief Free memory of Ethernet PHY instance
+    *
+    * @param[in] phy: Ethernet PHY instance
+    *
+    * @return
+    *      - ESP_OK: free PHY instance successfully
+    *      - ESP_FAIL: free PHY instance failed because some error occurred
+    *
+    */
+    esp_err_t (*del)(esp_eth_phy_t* phy);
+};
+
+/**
+* @brief Ethernet PHY configuration
+*
+*/
+typedef struct {
+    int32_t phy_addr;             /*!< PHY address, set -1 to enable PHY address detection at initialization stage */
+    uint32_t reset_timeout_ms;    /*!< Reset timeout value (Unit: ms) */
+    uint32_t autonego_timeout_ms; /*!< Auto-negotiation timeout value (Unit: ms) */
+    int reset_gpio_num;           /*!< Reset GPIO number, -1 means no hardware reset */
+} eth_phy_config_t;
+
+/**
+ * @brief Default configuration for Ethernet PHY object
+ *
+ */
+#define ETH_PHY_DEFAULT_CONFIG()           \
+    {                                      \
+        .phy_addr = ESP_ETH_PHY_ADDR_AUTO, \
+        .reset_timeout_ms = 100,           \
+        .autonego_timeout_ms = 4000,       \
+        .reset_gpio_num = 5,               \
+    }
+
+inline esp_eth_phy_t*
+esp_eth_phy_new_mock(const eth_phy_config_t* /*config*/)
+{
+    return nullptr;
+};

--- a/mock-idf/components/esp_netif/include/esp_netif.h
+++ b/mock-idf/components/esp_netif/include/esp_netif.h
@@ -2,6 +2,7 @@
 
 #include <esp_netif_types.h>
 #include <esp_netif_ip_addr.h>
+#include <esp_err.h>
 
 inline esp_err_t esp_netif_set_hostname(esp_netif_t */*esp_netif*/, const char */*hostname*/) { return ESP_OK; }
 
@@ -10,3 +11,9 @@ inline void esp_netif_destroy(esp_netif_t* /*esp_netif*/) {}
 inline esp_err_t esp_netif_init(void) { return ESP_OK; }
 
 inline esp_err_t esp_netif_deinit(void) { return ESP_OK; }
+
+inline esp_err_t esp_netif_get_mac(esp_netif_t */*esp_netif*/, uint8_t /*mac*/[]){ return ESP_OK; };
+
+inline esp_err_t esp_netif_attach(esp_netif_t */*esp_netif*/, esp_netif_iodriver_handle /*driver_handle*/){ return ESP_OK; };
+
+inline esp_netif_t *esp_netif_new(const esp_netif_config_t */*esp_netif_config*/){ return nullptr; };

--- a/mock-idf/components/esp_netif/include/esp_netif_types.h
+++ b/mock-idf/components/esp_netif/include/esp_netif_types.h
@@ -2,4 +2,9 @@
 
 struct esp_netif_obj {};
 
+typedef void* esp_netif_iodriver_handle;
+
+typedef struct {
+} esp_netif_config_t;
+
 typedef struct esp_netif_obj esp_netif_t;

--- a/smooth_component/Kconfig
+++ b/smooth_component/Kconfig
@@ -20,9 +20,9 @@ config SMOOTH_MAX_MQTT_MESSAGE_SIZE
     default 512
     help
         MQTT allows messages sizes up to 268435455 bytes in its remaning lengths field which is obviously
-	too much data to hold in memory on an embedded device. Any incoming message with a remaining length
-	larger than the set value will be 'swallowed' by the Smooth MQTT protocol implementation and never
-	seen by the application.
+	    too much data to hold in memory on an embedded device. Any incoming message with a remaining length
+	    larger than the set value will be 'swallowed' by the Smooth MQTT protocol implementation and never
+	    seen by the application.
 
 config SMOOTH_MAX_MQTT_OUTGOING_MESSAGES
     int "Maximum number of queued outgoing messages"
@@ -39,13 +39,13 @@ choice
 config SMOOTH_MQTT_LOG_LEVEL_NONE
     bool "None"
 config SMOOTH_MQTT_LOG_LEVEL_ERROR
-   bool "Error"
+    bool "Error"
 config SMOOTH_MQTT_LOG_LEVEL_WARN
-   bool "Warning"
+    bool "Warning"
 config SMOOTH_MQTT_LOG_LEVEL_INFO
-   bool "Info"
+    bool "Info"
 config SMOOTH_MQTT_LOG_LEVEL_DEBUG
-   bool "Debug"
+    bool "Debug"
 config SMOOTH_MQTT_LOG_LEVEL_VERBOSE
     bool "Verbose"
 endchoice
@@ -58,4 +58,148 @@ config SMOOTH_MQTT_LOGGING_LEVEL
     default 3 if SMOOTH_MQTT_LOG_LEVEL_INFO
     default 4 if SMOOTH_MQTT_LOG_LEVEL_DEBUG
     default 5 if SMOOTH_MQTT_LOG_LEVEL_VERBOSE
+
+
+menu "Ethernet"
+    choice SMOOTH_USE_ETHERNET
+        prompt "Ethernet Type"
+        default SMOOTH_USE_INTERNAL_ETHERNET if IDF_TARGET_ESP32
+        default SMOOTH_USE_DM9051 if !IDF_TARGET_ESP32
+        help
+            Select which kind of Ethernet will be used in the example.
+
+        config SMOOTH_USE_INTERNAL_ETHERNET
+            depends on IDF_TARGET_ESP32
+            select ETH_USE_ESP32_EMAC
+            bool "Internal EMAC"
+            help
+                Select internal Ethernet MAC controller.
+
+        config SMOOTH_USE_DM9051
+            bool "DM9051 Module"
+            select ETH_USE_SPI_ETHERNET
+            select ETH_SPI_ETHERNET_DM9051
+            help
+                Select external SPI-Ethernet module (DM9051).
+
+    endchoice
+
+    if SMOOTH_USE_INTERNAL_ETHERNET
+        choice SMOOTH_ETH_PHY_MODEL
+            prompt "Ethernet PHY Device"
+            default SMOOTH_ETH_PHY_IP101
+            help
+                Select the Ethernet PHY device to use.
+
+            config SMOOTH_ETH_PHY_IP101
+                bool "IP101"
+                help
+                    IP101 is a single port 10/100 MII/RMII/TP/Fiber Fast Ethernet Transceiver.
+                    Goto http://www.icplus.com.tw/pp-IP101G.html for more information about it.
+
+            config SMOOTH_ETH_PHY_RTL8201
+                bool "RTL8201/SR8201"
+                help
+                    RTL8201F/SR8201F is a single port 10/100Mb Ethernet Transceiver with auto MDIX.
+                    Goto http://www.corechip-sz.com/productsview.asp?id=22 for more information about it.
+
+            config SMOOTH_ETH_PHY_LAN8720
+                bool "LAN8720"
+                help
+                    LAN8720A is a small footprint RMII 10/100 Ethernet Transceiver with HP Auto-MDIX Support.
+                    Goto https://www.microchip.com/LAN8720A for more information about it.
+            
+            config SMOOTH_ETH_PHY_LAN8742
+                bool "LAN8742"
+                help
+                    LAN87242A is a small footprint RMII 10/100 Ethernet Transceiver with HP Auto-MDIX Support.
+                    Goto https://www.microchip.com/LAN8742A for more information about it.
+
+            config SMOOTH_ETH_PHY_DP83848
+                bool "DP83848"
+                help
+                    DP83848 is a single port 10/100Mb/s Ethernet Physical Layer Transceiver.
+                    Goto http://www.ti.com/product/DP83848J for more information about it.
+        endchoice
+
+        config SMOOTH_ETH_MDC_GPIO
+            int "SMI MDC GPIO number"
+            default 23
+            help
+                Set the GPIO number used by SMI MDC.
+
+        config SMOOTH_ETH_MDIO_GPIO
+            int "SMI MDIO GPIO number"
+            default 18
+            help
+                Set the GPIO number used by SMI MDIO.
+    endif
+
+    if SMOOTH_USE_DM9051
+        config SMOOTH_DM9051_SPI_HOST
+            int "SPI Host Number"
+            range 0 2
+            default 1
+            help
+                Set the SPI host used to communicate with the SPI Ethernet Controller.
+
+        config SMOOTH_DM9051_SCLK_GPIO
+            int "SPI SCLK GPIO number"
+            range 0 33
+            default 19
+            help
+                Set the GPIO number used by SPI SCLK.
+
+        config SMOOTH_DM9051_MOSI_GPIO
+            int "SPI MOSI GPIO number"
+            range 0 33
+            default 23
+            help
+                Set the GPIO number used by SPI MOSI.
+
+        config SMOOTH_DM9051_MISO_GPIO
+            int "SPI MISO GPIO number"
+            range 0 33
+            default 25
+            help
+                Set the GPIO number used by SPI MISO.
+
+        config SMOOTH_DM9051_CS_GPIO
+            int "SPI CS GPIO number"
+            range 0 33
+            default 22
+            help
+                Set the GPIO number used by SPI CS.
+
+        config SMOOTH_DM9051_SPI_CLOCK_MHZ
+            int "SPI clock speed (MHz)"
+            range 5 80
+            default 20
+            help
+                Set the clock speed (MHz) of SPI interface.
+
+        config SMOOTH_DM9051_INT_GPIO
+            int "Interrupt GPIO number"
+            default 4
+            help
+                Set the GPIO number used by DM9051 interrupt.
+    endif
+
+    config SMOOTH_ETH_PHY_RST_GPIO
+        int "PHY Reset GPIO number"
+        default 5
+        help
+            Set the GPIO number used to reset PHY chip.
+            Set to -1 to disable PHY chip hardware reset.
+
+    config SMOOTH_ETH_PHY_ADDR
+        int "PHY Address"
+        range 0 31 if SMOOTH_USE_INTERNAL_ETHERNET
+        range 1 1 if !SMOOTH_USE_INTERNAL_ETHERNET
+        default 0 if SMOOTH_USE_INTERNAL_ETHERNET
+        default 1 if !SMOOTH_USE_INTERNAL_ETHERNET
+        help
+            Set PHY address according your board schematic.
+endmenu
+    
 endmenu

--- a/test/access_point/access_point.cpp
+++ b/test/access_point/access_point.cpp
@@ -60,7 +60,7 @@ namespace access_point
 
                 std::array<uint8_t, 6> mac{};
 
-                if (Wifi::get_local_mac_address(mac))
+                if (get_wifi().get_local_mac_address(mac))
                 {
                     mac_str = fmt::format(mac_format, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
                     Log::info(tag, mac_str);
@@ -70,7 +70,7 @@ namespace access_point
                     Log::error(tag, "Could not get local MAC");
                 }
 
-                auto ip = Wifi::get_local_ip();
+                auto ip = get_wifi().get_local_ip();
 
                 if (ip)
                 {

--- a/test/server_socket_ethernet_test/CMakeLists.txt
+++ b/test/server_socket_ethernet_test/CMakeLists.txt
@@ -1,0 +1,34 @@
+#[[
+Smooth - A C++ framework for embedded programming on top of Espressif's ESP-IDF
+Copyright 2019 Per Malmberg (https://gitbub.com/PerMalmberg)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]]
+
+
+
+get_filename_component(TEST_PROJECT ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+
+set(TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/generated_test_smooth_${TEST_PROJECT}.cpp)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/../test.cpp.in ${TEST_SRC})
+set(TEST_PROJECT_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+# As project() isn't scriptable and the entire file is evaluated we work around the limitation by generating
+# the actual file used for the respective platform.
+if(NOT "${COMPONENT_DIR}" STREQUAL "")
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/../test_project_template_esp.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/generated_test_esp.cmake @ONLY)
+    include(${CMAKE_CURRENT_BINARY_DIR}/generated_test_esp.cmake)
+else()
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/../test_project_template_linux.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/generated_test_linux.cmake @ONLY)
+    include(${CMAKE_CURRENT_BINARY_DIR}/generated_test_linux.cmake)
+endif()

--- a/test/server_socket_ethernet_test/StreamPacket.h
+++ b/test/server_socket_ethernet_test/StreamPacket.h
@@ -20,34 +20,35 @@ limitations under the License.
 #include <array>
 
 class StreamPacket
-    : public smooth::core::network::IPacketDisassembly {
-public:
-    StreamPacket() = default;
+    : public smooth::core::network::IPacketDisassembly
+{
+    public:
+        StreamPacket() = default;
 
-    StreamPacket(const StreamPacket&) = default;
+        StreamPacket(const StreamPacket&) = default;
 
-    StreamPacket& operator=(const StreamPacket&) = default;
+        StreamPacket& operator=(const StreamPacket&) = default;
 
-    explicit StreamPacket(char c)
-    {
-        buff[0] = static_cast<unsigned char>(c);
-    }
+        explicit StreamPacket(char c)
+        {
+            buff[0] = static_cast<unsigned char>(c);
+        }
 
-    int get_send_length() override
-    {
-        return static_cast<int>(buff.size());
-    }
+        int get_send_length() override
+        {
+            return static_cast<int>(buff.size());
+        }
 
-    const uint8_t* get_data() override
-    {
-        return buff.data();
-    }
+        const uint8_t* get_data() override
+        {
+            return buff.data();
+        }
 
-    std::array<uint8_t, 1>& data()
-    {
-        return buff;
-    }
+        std::array<uint8_t, 1>& data()
+        {
+            return buff;
+        }
 
-private:
-    std::array<uint8_t, 1> buff{};
+    private:
+        std::array<uint8_t, 1> buff{};
 };

--- a/test/server_socket_ethernet_test/StreamPacket.h
+++ b/test/server_socket_ethernet_test/StreamPacket.h
@@ -16,28 +16,38 @@ limitations under the License.
 */
 
 #pragma once
+#include "smooth/core/network/IPacketDisassembly.h"
+#include <array>
 
-#include "StreamingClient.h"
-#include "StreamingProtocol.h"
-#include "smooth/core/Application.h"
-#include "smooth/core/ipc/IEventListener.h"
-#include "smooth/core/ipc/TaskEventQueue.h"
-#include "smooth/core/network/SecureSocket.h"
-#include "smooth/core/network/ServerSocket.h"
-#include "smooth/core/network/Socket.h"
-#include <functional>
-
-namespace server_socket_test {
-class App
-    : public smooth::core::Application {
+class StreamPacket
+    : public smooth::core::network::IPacketDisassembly {
 public:
-    App();
+    StreamPacket() = default;
 
-    void init() override;
+    StreamPacket(const StreamPacket&) = default;
+
+    StreamPacket& operator=(const StreamPacket&) = default;
+
+    explicit StreamPacket(char c)
+    {
+        buff[0] = static_cast<unsigned char>(c);
+    }
+
+    int get_send_length() override
+    {
+        return static_cast<int>(buff.size());
+    }
+
+    const uint8_t* get_data() override
+    {
+        return buff.data();
+    }
+
+    std::array<uint8_t, 1>& data()
+    {
+        return buff;
+    }
 
 private:
-    std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
-                                                        StreamingProtocol, void>>
-        server{};
+    std::array<uint8_t, 1> buff{};
 };
-}

--- a/test/server_socket_ethernet_test/StreamingClient.h
+++ b/test/server_socket_ethernet_test/StreamingClient.h
@@ -1,0 +1,72 @@
+/*
+Smooth - A C++ framework for embedded programming on top of Espressif's ESP-IDF
+Copyright 2019 Per Malmberg (https://gitbub.com/PerMalmberg)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "StreamingProtocol.h"
+#include "smooth/core/ipc/IEventListener.h"
+#include "smooth/core/logging/log.h"
+#include "smooth/core/network/BufferContainer.h"
+#include "smooth/core/network/ServerClient.h"
+#include "smooth/core/network/event/DataAvailableEvent.h"
+#include <chrono>
+
+namespace server_socket_ethernet_test {
+class StreamingClient
+    : public smooth::core::network::ServerClient<StreamingClient, StreamingProtocol, void> {
+public:
+    explicit StreamingClient(smooth::core::Task& task, smooth::core::network::ClientPool<StreamingClient>& pool)
+        : ServerClient<StreamingClient, StreamingProtocol, void>(task, pool,
+                                                                 std::make_unique<StreamingProtocol>())
+    {
+    }
+
+    ~StreamingClient() override = default;
+
+    void event(const smooth::core::network::event::DataAvailableEvent<StreamingProtocol>& event) override
+    {
+        // Print data as it is received.
+        StreamingProtocol::packet_type packet;
+
+        if (event.get(packet)) {
+            std::string s{static_cast<char>(packet.data()[0])};
+            smooth::core::logging::Log::debug("-->", s);
+        }
+    }
+
+    void event(const smooth::core::network::event::TransmitBufferEmptyEvent& /*event*/) override
+    {
+    }
+
+    void disconnected() override
+    {
+    }
+
+    void connected() override
+    {
+    }
+
+    void reset_client() override
+    {
+    }
+
+    std::chrono::milliseconds get_send_timeout() override
+    {
+        return std::chrono::seconds{1};
+    }
+};
+}

--- a/test/server_socket_ethernet_test/StreamingClient.h
+++ b/test/server_socket_ethernet_test/StreamingClient.h
@@ -26,47 +26,49 @@ limitations under the License.
 #include <chrono>
 
 namespace server_socket_ethernet_test {
-class StreamingClient
-    : public smooth::core::network::ServerClient<StreamingClient, StreamingProtocol, void> {
-public:
-    explicit StreamingClient(smooth::core::Task& task, smooth::core::network::ClientPool<StreamingClient>& pool)
-        : ServerClient<StreamingClient, StreamingProtocol, void>(task, pool,
-                                                                 std::make_unique<StreamingProtocol>())
+    class StreamingClient
+        : public smooth::core::network::ServerClient<StreamingClient, StreamingProtocol, void>
     {
-    }
+        public:
+            explicit StreamingClient(smooth::core::Task& task, smooth::core::network::ClientPool<StreamingClient>& pool)
+                    : ServerClient<StreamingClient, StreamingProtocol, void>(task, pool,
+                                                                             std::make_unique<StreamingProtocol>())
+            {
+            }
 
-    ~StreamingClient() override = default;
+            ~StreamingClient() override = default;
 
-    void event(const smooth::core::network::event::DataAvailableEvent<StreamingProtocol>& event) override
-    {
-        // Print data as it is received.
-        StreamingProtocol::packet_type packet;
+            void event(const smooth::core::network::event::DataAvailableEvent<StreamingProtocol>& event) override
+            {
+                // Print data as it is received.
+                StreamingProtocol::packet_type packet;
 
-        if (event.get(packet)) {
-            std::string s{static_cast<char>(packet.data()[0])};
-            smooth::core::logging::Log::debug("-->", s);
-        }
-    }
+                if (event.get(packet))
+                {
+                    std::string s{ static_cast<char>(packet.data()[0]) };
+                    smooth::core::logging::Log::debug("-->", s);
+                }
+            }
 
-    void event(const smooth::core::network::event::TransmitBufferEmptyEvent& /*event*/) override
-    {
-    }
+            void event(const smooth::core::network::event::TransmitBufferEmptyEvent& /*event*/) override
+            {
+            }
 
-    void disconnected() override
-    {
-    }
+            void disconnected() override
+            {
+            }
 
-    void connected() override
-    {
-    }
+            void connected() override
+            {
+            }
 
-    void reset_client() override
-    {
-    }
+            void reset_client() override
+            {
+            }
 
-    std::chrono::milliseconds get_send_timeout() override
-    {
-        return std::chrono::seconds{1};
-    }
-};
+            std::chrono::milliseconds get_send_timeout() override
+            {
+                return std::chrono::seconds{ 1 };
+            }
+    };
 }

--- a/test/server_socket_ethernet_test/StreamingProtocol.h
+++ b/test/server_socket_ethernet_test/StreamingProtocol.h
@@ -1,0 +1,70 @@
+/*
+Smooth - A C++ framework for embedded programming on top of Espressif's ESP-IDF
+Copyright 2019 Per Malmberg (https://gitbub.com/PerMalmberg)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "StreamPacket.h"
+#include "smooth/core/network/IPacketAssembly.h"
+#include "smooth/core/network/IPacketDisassembly.h"
+#include <array>
+
+namespace server_socket_ethernet_test {
+class StreamingProtocol
+    : public smooth::core::network::IPacketAssembly<StreamingProtocol, StreamPacket> {
+public:
+    using packet_type = StreamPacket;
+
+    int get_wanted_amount(StreamPacket& /*packet*/) override
+    {
+        return 1;
+    }
+
+    void data_received(StreamPacket& /*packet*/, int /*length*/) override
+    {
+        complete = true;
+    }
+
+    uint8_t* get_write_pos(StreamPacket& packet) override
+    {
+        return packet.data().data();
+    }
+
+    bool is_complete(StreamPacket& /*packet*/) const override
+    {
+        return complete;
+    }
+
+    bool is_error() override
+    {
+        // Can't fail when there really is no actual protocol.
+        return false;
+    }
+
+    void packet_consumed() override
+    {
+        complete = false;
+    }
+
+    void reset() override
+    {
+        packet_consumed();
+    }
+
+private:
+    bool complete{false};
+};
+}

--- a/test/server_socket_ethernet_test/StreamingProtocol.h
+++ b/test/server_socket_ethernet_test/StreamingProtocol.h
@@ -23,48 +23,49 @@ limitations under the License.
 #include <array>
 
 namespace server_socket_ethernet_test {
-class StreamingProtocol
-    : public smooth::core::network::IPacketAssembly<StreamingProtocol, StreamPacket> {
-public:
-    using packet_type = StreamPacket;
-
-    int get_wanted_amount(StreamPacket& /*packet*/) override
+    class StreamingProtocol
+        : public smooth::core::network::IPacketAssembly<StreamingProtocol, StreamPacket>
     {
-        return 1;
-    }
+        public:
+            using packet_type = StreamPacket;
 
-    void data_received(StreamPacket& /*packet*/, int /*length*/) override
-    {
-        complete = true;
-    }
+            int get_wanted_amount(StreamPacket& /*packet*/) override
+            {
+                return 1;
+            }
 
-    uint8_t* get_write_pos(StreamPacket& packet) override
-    {
-        return packet.data().data();
-    }
+            void data_received(StreamPacket& /*packet*/, int /*length*/) override
+            {
+                complete = true;
+            }
 
-    bool is_complete(StreamPacket& /*packet*/) const override
-    {
-        return complete;
-    }
+            uint8_t* get_write_pos(StreamPacket& packet) override
+            {
+                return packet.data().data();
+            }
 
-    bool is_error() override
-    {
-        // Can't fail when there really is no actual protocol.
-        return false;
-    }
+            bool is_complete(StreamPacket& /*packet*/) const override
+            {
+                return complete;
+            }
 
-    void packet_consumed() override
-    {
-        complete = false;
-    }
+            bool is_error() override
+            {
+                // Can't fail when there really is no actual protocol.
+                return false;
+            }
 
-    void reset() override
-    {
-        packet_consumed();
-    }
+            void packet_consumed() override
+            {
+                complete = false;
+            }
 
-private:
-    bool complete{false};
-};
+            void reset() override
+            {
+                packet_consumed();
+            }
+
+        private:
+            bool complete{ false };
+    };
 }

--- a/test/server_socket_ethernet_test/server_socket_ethernet_test.cpp
+++ b/test/server_socket_ethernet_test/server_socket_ethernet_test.cpp
@@ -1,0 +1,68 @@
+/*
+Smooth - A C++ framework for embedded programming on top of Espressif's ESP-IDF
+Copyright 2019 Per Malmberg (https://gitbub.com/PerMalmberg)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "server_socket_ethernet_test.h"
+#include "smooth/core/Application.h"
+#include "smooth/core/Task.h"
+#include "smooth/core/logging/log.h"
+#include "smooth/core/network/IPv4.h"
+#include "smooth/core/network/SecureServerSocket.h"
+#include "smooth/core/network/ServerSocket.h"
+#include "smooth/core/task_priorities.h"
+#include "wifi_creds.h"
+#include <deque>
+
+using namespace std::chrono;
+using namespace smooth::core;
+using namespace smooth::core::network;
+using namespace smooth::core::network::event;
+using namespace smooth::core::logging;
+
+namespace server_socket_ethernet_test {
+App::App()
+    : Application(smooth::core::APPLICATION_BASE_PRIO, std::chrono::milliseconds(1000))
+{
+}
+
+void
+App::init()
+{
+    Application::init();
+
+    // connects to both ethernet and wifi
+    // which each have a unique host name
+
+    Log::info("App::Init", "Starting Ethernet...");
+    ethernet.set_host_name("smooth_wired");
+    ethernet.start();
+
+    Log::info("App::Init", "Starting wifi...");
+    network::Wifi& wifi = get_wifi();
+    wifi.set_host_name("smooth_wifi");
+    wifi.set_auto_connect(true);
+    wifi.set_ap_credentials(WIFI_SSID, WIFI_PASSWORD);
+    wifi.connect_to_ap();
+
+    // The server creates StreamingClients which are self-sufficient and never seen by the main
+    // application (unless the implementor adds such bindings).
+    server = ServerSocket<StreamingClient, StreamingProtocol, void>::create(*this, 5, 5);
+    server->start(std::make_shared<IPv4>("0.0.0.0", 8080));
+
+    // Point your browser to http://localhost:8080 and watch the output.
+    // Or, if you're on linux, do "echo ` date` | nc localhost 8080 -w1"
+}
+}

--- a/test/server_socket_ethernet_test/server_socket_ethernet_test.cpp
+++ b/test/server_socket_ethernet_test/server_socket_ethernet_test.cpp
@@ -33,36 +33,35 @@ using namespace smooth::core::network::event;
 using namespace smooth::core::logging;
 
 namespace server_socket_ethernet_test {
-App::App()
-    : Application(smooth::core::APPLICATION_BASE_PRIO, std::chrono::milliseconds(1000))
-{
-}
+    App::App()
+            : Application(smooth::core::APPLICATION_BASE_PRIO, std::chrono::milliseconds(1000))
+    {
+    }
 
-void
-App::init()
-{
-    Application::init();
+    void App::init()
+    {
+        Application::init();
 
-    // connects to both ethernet and wifi
-    // which each have a unique host name
+        // connects to both ethernet and wifi
+        // which each have a unique host name
 
-    Log::info("App::Init", "Starting Ethernet...");
-    ethernet.set_host_name("smooth_wired");
-    ethernet.start();
+        Log::info("App::Init", "Starting Ethernet...");
+        ethernet.set_host_name("smooth_wired");
+        ethernet.start();
 
-    Log::info("App::Init", "Starting wifi...");
-    network::Wifi& wifi = get_wifi();
-    wifi.set_host_name("smooth_wifi");
-    wifi.set_auto_connect(true);
-    wifi.set_ap_credentials(WIFI_SSID, WIFI_PASSWORD);
-    wifi.connect_to_ap();
+        Log::info("App::Init", "Starting wifi...");
+        network::Wifi& wifi = get_wifi();
+        wifi.set_host_name("smooth_wifi");
+        wifi.set_auto_connect(true);
+        wifi.set_ap_credentials(WIFI_SSID, WIFI_PASSWORD);
+        wifi.connect_to_ap();
 
-    // The server creates StreamingClients which are self-sufficient and never seen by the main
-    // application (unless the implementor adds such bindings).
-    server = ServerSocket<StreamingClient, StreamingProtocol, void>::create(*this, 5, 5);
-    server->start(std::make_shared<IPv4>("0.0.0.0", 8080));
+        // The server creates StreamingClients which are self-sufficient and never seen by the main
+        // application (unless the implementor adds such bindings).
+        server = ServerSocket<StreamingClient, StreamingProtocol, void>::create(*this, 5, 5);
+        server->start(std::make_shared<IPv4>("0.0.0.0", 8080));
 
-    // Point your browser to http://localhost:8080 and watch the output.
-    // Or, if you're on linux, do "echo ` date` | nc localhost 8080 -w1"
-}
+        // Point your browser to http://localhost:8080 and watch the output.
+        // Or, if you're on linux, do "echo ` date` | nc localhost 8080 -w1"
+    }
 }

--- a/test/server_socket_ethernet_test/server_socket_ethernet_test.h
+++ b/test/server_socket_ethernet_test/server_socket_ethernet_test.h
@@ -29,18 +29,19 @@ limitations under the License.
 #include <functional>
 
 namespace server_socket_ethernet_test {
-class App
-    : public smooth::core::Application {
-public:
-    App();
+    class App
+        : public smooth::core::Application
+    {
+        public:
+            App();
 
-    void init() override;
+            void init() override;
 
-private:
-    std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
-                                                        StreamingProtocol, void>>
-        server{};
+        private:
+            std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
+                                                                StreamingProtocol, void>>
+            server{};
 
-    smooth::core::network::Ethernet ethernet;
-};
+            smooth::core::network::Ethernet ethernet;
+    };
 }

--- a/test/server_socket_ethernet_test/server_socket_ethernet_test.h
+++ b/test/server_socket_ethernet_test/server_socket_ethernet_test.h
@@ -22,12 +22,13 @@ limitations under the License.
 #include "smooth/core/Application.h"
 #include "smooth/core/ipc/IEventListener.h"
 #include "smooth/core/ipc/TaskEventQueue.h"
+#include "smooth/core/network/Ethernet.h"
 #include "smooth/core/network/SecureSocket.h"
 #include "smooth/core/network/ServerSocket.h"
 #include "smooth/core/network/Socket.h"
 #include <functional>
 
-namespace server_socket_test {
+namespace server_socket_ethernet_test {
 class App
     : public smooth::core::Application {
 public:
@@ -39,5 +40,7 @@ private:
     std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
                                                         StreamingProtocol, void>>
         server{};
+
+    smooth::core::network::Ethernet ethernet;
 };
 }

--- a/test/server_socket_ethernet_test/wifi_creds.h
+++ b/test/server_socket_ethernet_test/wifi_creds.h
@@ -17,27 +17,5 @@ limitations under the License.
 
 #pragma once
 
-#include "StreamingClient.h"
-#include "StreamingProtocol.h"
-#include "smooth/core/Application.h"
-#include "smooth/core/ipc/IEventListener.h"
-#include "smooth/core/ipc/TaskEventQueue.h"
-#include "smooth/core/network/SecureSocket.h"
-#include "smooth/core/network/ServerSocket.h"
-#include "smooth/core/network/Socket.h"
-#include <functional>
-
-namespace server_socket_test {
-class App
-    : public smooth::core::Application {
-public:
-    App();
-
-    void init() override;
-
-private:
-    std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
-                                                        StreamingProtocol, void>>
-        server{};
-};
-}
+#define WIFI_SSID "Your SSID"
+#define WIFI_PASSWORD "Your password"

--- a/test/server_socket_test/server_socket_test.h
+++ b/test/server_socket_test/server_socket_test.h
@@ -28,16 +28,17 @@ limitations under the License.
 #include <functional>
 
 namespace server_socket_test {
-class App
-    : public smooth::core::Application {
-public:
-    App();
+    class App
+        : public smooth::core::Application
+    {
+        public:
+            App();
 
-    void init() override;
+            void init() override;
 
-private:
-    std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
-                                                        StreamingProtocol, void>>
-        server{};
-};
+        private:
+            std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
+                                                                StreamingProtocol, void>>
+            server{};
+    };
 }

--- a/test/server_socket_test/server_socket_test.h
+++ b/test/server_socket_test/server_socket_test.h
@@ -17,17 +17,18 @@ limitations under the License.
 
 #pragma once
 
-#include "StreamingClient.h"
-#include "StreamingProtocol.h"
+#include <functional>
 #include "smooth/core/Application.h"
+#include "smooth/core/network/SecureSocket.h"
 #include "smooth/core/ipc/IEventListener.h"
 #include "smooth/core/ipc/TaskEventQueue.h"
-#include "smooth/core/network/SecureSocket.h"
-#include "smooth/core/network/ServerSocket.h"
 #include "smooth/core/network/Socket.h"
-#include <functional>
+#include "smooth/core/network/ServerSocket.h"
+#include "StreamingProtocol.h"
+#include "StreamingClient.h"
 
-namespace server_socket_test {
+namespace server_socket_test
+{
     class App
         : public smooth::core::Application
     {
@@ -38,7 +39,6 @@ namespace server_socket_test {
 
         private:
             std::shared_ptr<smooth::core::network::ServerSocket<StreamingClient,
-                                                                StreamingProtocol, void>>
-            server{};
+                                                                StreamingProtocol, void>> server{};
     };
 }


### PR DESCRIPTION
First of all, your framework looks well designed so I think this could be my first of many PR's.

I added support for wired Ethernet, which required a refactor of the WiFi class too.
Please let me know your thoughts on the changes.

I tested this on custom hardware with the internal MAC and a LAN8742 phy.
The LAN8742 is very similar to the 8720, but not included yet in esp-idf. Will later send a PR for that to esp-idf.

**Changes**
- Added a base class for a network interface. Moved managing hostname, interface, and addresses to this base class. The network class counts the number of interfaces because the network stack should only be initialized once per application.
- Changed how host_name is stored. esp_idf only copies a pointer, so string.c_str() can become invalid if the string is reallocated. host_name should also be set before the interface is started. I chose to store the hostname in each interface, so they can have a unique hostname. An alternative is to make the hostname static and use the same for both wifi and ethernet. Not sure what is desired here.
- Added Ethernet class. Code is based on the ethernet basic example from esp-idf.
- Added ethernet settings to kconfig
- Added copy of socket_server_test that also uses ethernet.

Result of test app and idf.py monitor below.
You can see that the ESP gets 2 ip addresses. Connections are accepted on both IPs, tested with:
```
echo ` date` | nc 192.168.1.115 8080 -w1
echo ` date` | nc 192.168.1.116 8080 -w1
```

<details>
<pre>
entry 0x40080688
I (29) boot: ESP-IDF v4.2-beta1-87-gb83aa9fda 2nd stage bootloader
I (29) boot: compile time 18:26:28
I (29) boot: chip revision: 1
I (33) boot_comm: chip revision: 1, min. bootloader chip revision: 0
I (40) boot.esp32: SPI Speed      : 40MHz
I (45) boot.esp32: SPI Mode       : DIO
I (50) boot.esp32: SPI Flash Size : 4MB
I (54) boot: Enabling RNG early entropy source...
I (60) boot: Partition Table:
I (63) boot: ## Label            Usage          Type ST Offset   Length
I (70) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (78) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (85) boot:  2 factory          factory app      00 00 00010000 00300000
I (93) boot:  3 app_storage      Unknown data     01 81 00310000 00084000
I (100) boot: End of partition table
I (105) boot_comm: chip revision: 1, min. application chip revision: 0
I (112) esp_image: segment 0: paddr=0x00010020 vaddr=0x3f400020 size=0x3b2ec (242412) map
I (213) esp_image: segment 1: paddr=0x0004b314 vaddr=0x3ffb0000 size=0x03dbc ( 15804) load
I (220) esp_image: segment 2: paddr=0x0004f0d8 vaddr=0x40080000 size=0x00404 (  1028) load
0x40080000: _WindowOverflow4 at /home/elco/repos/esp-idf/components/freertos/xtensa/xtensa_vectors.S:1730

I (221) esp_image: segment 3: paddr=0x0004f4e4 vaddr=0x40080404 size=0x00b34 (  2868) load
I (230) esp_image: segment 4: paddr=0x00050020 vaddr=0x400d0020 size=0xc4214 (803348) map
0x400d0020: _stext at ??:?

I (543) esp_image: segment 5: paddr=0x0011423c vaddr=0x40080f38 size=0x154fc ( 87292) load
I (594) boot: Loaded app from partition at offset 0x10000
I (594) boot: Disabling RNG early entropy source...
I (594) cpu_start: Pro cpu up.
I (598) cpu_start: Application information:
I (603) cpu_start: Project name:     server_socket_ethernet_test
I (609) cpu_start: App version:      9de844f-dirty
I (615) cpu_start: Compile time:     Oct 17 2020 18:38:57
I (621) cpu_start: ELF file SHA256:  d997a84045d58fce...
I (627) cpu_start: ESP-IDF:          v4.2-beta1-87-gb83aa9fda
I (633) cpu_start: Starting app cpu, entry point is 0x400818a0
0x400818a0: call_start_cpu1 at /home/elco/repos/esp-idf/components/esp32/cpu_start.c:282

I (0) cpu_start: App cpu up.
I (644) heap_init: Initializing. RAM available for dynamic allocation:
I (651) heap_init: At 3FFAE6E0 len 00001920 (6 KiB): DRAM
I (657) heap_init: At 3FFB9D90 len 00026270 (152 KiB): DRAM
I (663) heap_init: At 3FFE0440 len 00003AE0 (14 KiB): D/IRAM
I (669) heap_init: At 3FFE4350 len 0001BCB0 (111 KiB): D/IRAM
I (676) heap_init: At 40096434 len 00009BCC (38 KiB): IRAM
I (682) cpu_start: Pro cpu start user code
I (729) spi_flash: detected chip: gd
I (730) spi_flash: flash io: dio
W (730) spi_flash: Detected size(16384k) larger than the size in the binary image header(4096k). Using the size in the binary image header.
I (740) cpu_start: Starting scheduler on PRO CPU.
I (0) cpu_start: Starting scheduler on APP CPU.
I (812) FSLock: Max number of open files set to: 5
I (825) system_api: Base MAC address is not set
I (825) system_api: read default base MAC address from EFUSE
I (838) App::Init: Starting Ethernet...
I (839) esp_eth.netif.glue: 24:62:ab:c3:8b:bf
I (839) esp_eth.netif.glue: ethernet attached to netif
I (853) App::Init: Starting wifi...
I (857) wifi:wifi driver task: 3ffcf9f0, prio:23, stack:3584, core=0
I (873) wifi:wifi firmware version: d3be909
I (873) wifi:wifi certification version: v7.0
I (873) wifi:config NVS flash: enabled
I (873) wifi:config nano formating: disabled
I (878) wifi:Init data frame dynamic rx buffer num: 32
I (882) wifi:Init management frame dynamic rx buffer num: 32
I (888) wifi:Init management short buffer num: 32
I (892) wifi:Init static tx buffer num: 16
I (896) wifi:Init static rx buffer size: 1600
I (900) wifi:Init static rx buffer num: 10
I (904) wifi:Init dynamic rx buffer num: 32
I (909) wifi_init: rx ba win: 16
I (911) wifi_init: tcpip mbox: 32
I (915) wifi_init: udp mbox: 6
I (919) wifi_init: tcp mbox: 6
I (923) wifi_init: tcp tx win: 5744
I (927) wifi_init: tcp rx win: 5744
I (931) wifi_init: tcp mss: 1440
I (935) wifi_init: WiFi IRAM OP enabled
I (940) wifi_init: WiFi RX IRAM OP enabled
I (1027) phy: phy_version: 4390, 6b3c1f2, Sep 10 2020, 15:09:07, 0, 0
I (1029) wifi:mode : sta (24:62:ab:c3:8b:bc)
I (1037) SocketDispatcher: Active sockets: 0
I (1637) wifi:new:<5,0>, old:<1,0>, ap:<255,255>, sta:<5,0>, prof:1
I (2173) wifi:state: init -> auth (b0)
I (2178) wifi:state: auth -> assoc (0)
I (2184) wifi:state: assoc -> run (10)
I (2211) wifi:connected with BrouwerijDeSchutter, aid = 3, channel 5, BW20, bssid = 7c:ff:4d:16:65:fa
I (2212) wifi:security: WPA2-PSK, phy: bg, rssi: -76
I (2215) wifi:pm start, type: 1

I (2352) wifi:AP's beacon interval = 102400 us, DTIM period = 1
I (3316) SocketDispatcher: Network up, sockets will be restarted.
I (3317) esp_netif_handlers: sta ip: 192.168.1.116, mask: 255.255.255.0, gw: 192.168.1.1
I (3318) SocketDispatcher: Network up, sockets will be restarted.
I (3330) Socket: [0.0.0.0, 8080, 54, 0x3ffdb9c0]: Created server socket
I (3815) esp_netif_handlers: eth ip: 192.168.1.115, mask: 255.255.255.0, gw: 192.168.1.1
I (3822) SocketDispatcher: Network up, sockets will be restarted.
I (3823) SocketDispatcher: Network up, sockets will be restarted.
I (3828) Socket: [0.0.0.0, 8080, 54, 0x3ffdb9c0]: Server stopping
E (3835) SocketDispatcher: Shutdown error: Invalid argument
I (3841) SocketDispatcher: Active sockets: 0
I (3846) SocketDispatcher: Active sockets: 0
I (3851) Socket: [0.0.0.0, 8080, 54, 0x3ffdb9c0]: Created server socket
I (13282) ServerSocket: Connection accepted
I (13284) SocketDispatcher: Active sockets: 2
I (14283) Socket: [, 0, 55, 0x3ffdd744]: Underlying socket closed (recv returned 0)
I (14283) Socket: [, 0, 55, 0x3ffdd744]: Socket stopping
I (14289) Socket: [, 0, -1, 0x3ffdd744]: Disconnected
I (14293) SocketDispatcher: Active sockets: 1
I (18954) ServerSocket: Connection accepted
I (18956) SocketDispatcher: Active sockets: 2
I (19971) Socket: [, 0, 55, 0x3ffdd744]: Underlying socket closed (recv returned 0)
I (19971) Socket: [, 0, 55, 0x3ffdd744]: Socket stopping
I (19977) Socket: [, 0, -1, 0x3ffdd744]: Disconnected
I (19980) SocketDispatcher: Active sockets: 1
</pre>
</details>

**Formatting**
For my own projects, I use clang-format. Integrates very nicely with vscode to format on save.
I ran uncrustify for this PR, because my clang-format rules are different.

I use these settings and the `xaver.clang-format` vscode plugin:
https://github.com/BrewBlox/brewblox-firmware/blob/develop/.clang-format

Have you tried/considered clang-format instead of uncrustify?

