### PR TITLE
added some more mime types to 'get_content_type()' in http_utils.cpp

### DIFF
--- a/lib/smooth/application/network/http/http_utils.cpp
+++ b/lib/smooth/application/network/http/http_utils.cpp
@@ -97,6 +97,34 @@ namespace smooth::application::network::http::utils
         {
             return "text/html";
         }
+        else if (ext == ".css")
+        {
+            return "text/css";
+        }
+        else if (ext == ".js")
+        {
+            return "text/javascript";
+        }
+        else if (ext == ".svg")
+        {
+            return "image/svg+xml";
+        }
+        else if (ext == ".gif")
+        {
+            return "image/gif";
+        }
+        else if (ext == ".json")
+        {
+            return "application/json";
+        }
+        else if (ext == ".mp3")
+        {
+            return "audio/mpeg";
+        }
+        else if (ext == ".ttf")
+        {
+            return "font/ttf";
+        }
 
         return "application/octet-stream";
     }

--- a/lib/smooth/application/network/http/http_utils.cpp
+++ b/lib/smooth/application/network/http/http_utils.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 #include "smooth/application/network/http/http_utils.h"
+#include "smooth/core/util/string_util.h"
 
 #include <array>
 #include <sstream>
@@ -87,7 +88,7 @@ namespace smooth::application::network::http::utils
     std::string get_content_type(const smooth::core::filesystem::Path& path)
     {
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
-        const auto& ext = path.extension();
+        const auto& ext = smooth::core::string_util::to_lower_copy(path.extension());
 
         if (ext == ".jpeg")
         {

--- a/lib/smooth/include/smooth/core/filesystem/SDCard.h
+++ b/lib/smooth/include/smooth/core/filesystem/SDCard.h
@@ -22,6 +22,7 @@ limitations under the License.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <sdmmc_cmd.h>
 #include <esp_vfs_fat.h>
 #include <esp_vfs.h>

--- a/lib/smooth/include/smooth/core/filesystem/SPIFlash.h
+++ b/lib/smooth/include/smooth/core/filesystem/SPIFlash.h
@@ -20,6 +20,7 @@ limitations under the License.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <esp_vfs.h>
 #include <esp_vfs_fat.h>
 #include <esp_system.h>

--- a/lib/smooth/include/smooth/core/io/spi/Master.h
+++ b/lib/smooth/include/smooth/core/io/spi/Master.h
@@ -21,6 +21,7 @@ limitations under the License.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <driver/gpio.h>
 #include <driver/spi_common.h>
 #include <driver/spi_master.h>

--- a/lib/smooth/include/smooth/core/io/spi/SPIDevice.h
+++ b/lib/smooth/include/smooth/core/io/spi/SPIDevice.h
@@ -20,6 +20,7 @@ limitations under the License.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <driver/gpio.h>
 #include <driver/spi_common.h>
 #include <driver/spi_master.h>


### PR DESCRIPTION
I added some more mime types to 'get_content_type()' in http_utils.cpp. 
Additionally I added `#pragma GCC diagnostic ignored "-Wold-style-cast"` to some header files because the actual master of esp-idf has some issues with old-style-cast.