### PR TITLE
Flag Sntp as started after starting

### DIFF
--- a/lib/smooth/core/sntp/Sntp.cpp
+++ b/lib/smooth/core/sntp/Sntp.cpp
@@ -49,6 +49,8 @@ namespace smooth::core::sntp
 
             sntp_set_time_sync_notification_cb(&Sntp::timeSyncNotificationCallback);
             sntp_init();
+            
+            started = true;
         }
 
 #ifndef ESP_PLATFORM


### PR DESCRIPTION
This appears to be missing. I can't find a place where `started` is set to anything but the initial value of `started = false`