### PR TITLE
Quick change to allow Smooth to compile on ESP32-S3.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         test_against_idf_versions:
-          - 'release-v5.0-dev'
           - 'release-v4.4'
           - 'release-v4.3'
           - 'release-v4.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       matrix:
         test_against_idf_versions:
-          - 'latest'
+          - 'release-v5.0-dev'
+          - 'release-v4.4'
           - 'release-v4.3'
           - 'release-v4.2'
     steps:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ Below is the list of individuals that have contributed to the project.
 |[COM8](https://github.com/COM8)|[PR#98](https://github.com/PerMalmberg/Smooth/pull/98)|
 |[enelson1001](https://github.com/enelson1001)|[PR#116](https://github.com/PerMalmberg/Smooth/pull/116), [PR#124](https://github.com/PerMalmberg/Smooth/pull/124), [PR#146](https://github.com/PerMalmberg/Smooth/pull/146), [PR#150](https://github.com/PerMalmberg/Smooth/pull/150)|
 |[peterus](https://github.com/peterus)|[PR#151](https://github.com/PerMalmberg/Smooth/pull/151), [PR#156](https://github.com/PerMalmberg/Smooth/pull/156)|
+|[tmiw](https://github.com/tmiw)|[PR#170](https://github.com/PerMalmberg/Smooth/pull/170)|

--- a/lib/smooth/core/io/spi/Master.cpp
+++ b/lib/smooth/core/io/spi/Master.cpp
@@ -26,9 +26,8 @@ namespace smooth::core::io::spi
     static constexpr const char* spi3_host_str = "SPI3_HOST";
 
     // Declare static variables
-    bool Master::hspi_initialized = false;
-    bool Master::vspi_initialized = false;
-    bool Master::spi_initialized = false;
+    bool Master::spi2_initialized = false;
+    bool Master::spi3_initialized = false;
     std::mutex Master::guard{};
     spi_bus_config_t Master::bus_config{};
     spi_host_device_t Master::spi_host;

--- a/lib/smooth/core/io/spi/Master.cpp
+++ b/lib/smooth/core/io/spi/Master.cpp
@@ -73,7 +73,7 @@ namespace smooth::core::io::spi
         }
 #else
 	// HSPI_HOST and VSPI_HOST deprecated for ESP32S2 and removed entirely for S3.
-        initialized = do_initialization(host, spi_initialized, spi_initialized_count, spi_host_str);
+        initialized = do_intitialization(host, spi_initialized, spi_initialized_count, spi_host_str);
 #endif // CONFIG_IDF_TARGET_ESP32
 
 

--- a/lib/smooth/core/io/spi/Master.cpp
+++ b/lib/smooth/core/io/spi/Master.cpp
@@ -22,9 +22,8 @@ using namespace smooth::core::logging;
 namespace smooth::core::io::spi
 {
     static constexpr const char* log_tag = "SPIMaster";
-    static constexpr const char* vspi_host_str = "VSPI_HOST";
-    static constexpr const char* hspi_host_str = "HSPI_HOST";
-    static constexpr const char* spi_host_str = "SPI_HOST";
+    static constexpr const char* spi2_host_str = "SPI2_HOST";
+    static constexpr const char* spi3_host_str = "SPI3_HOST";
 
     // Declare static variables
     bool Master::hspi_initialized = false;
@@ -34,9 +33,8 @@ namespace smooth::core::io::spi
     spi_bus_config_t Master::bus_config{};
     spi_host_device_t Master::spi_host;
     SPI_DMA_Channel Master::dma_channel;
-    uint8_t Master::hspi_initialized_count = 0;
-    uint8_t Master::vspi_initialized_count = 0;
-    uint8_t Master::spi_initialized_count = 0;
+    uint8_t Master::spi2_initialized_count = 0;
+    uint8_t Master::spi3_initialized_count = 0;
 
     bool Master::initialize(spi_host_device_t host,
                             SPI_DMA_Channel dma_chl,
@@ -61,21 +59,15 @@ namespace smooth::core::io::spi
 
         bool initialized = false;
 
-#ifdef CONFIG_IDF_TARGET_ESP32
-        if (spi_host == VSPI_HOST)
+        if (spi_host == SPI2_HOST)
         {
-            initialized = do_intitialization(VSPI_HOST, vspi_initialized, vspi_initialized_count, vspi_host_str);
+            initialized = do_intitialization(SPI2_HOST, spi2_initialized, spi2_initialized_count, spi2_host_str);
         }
 
-        if (spi_host == HSPI_HOST)
+        if (spi_host == SPI3_HOST)
         {
-            initialized = do_intitialization(HSPI_HOST, hspi_initialized, hspi_initialized_count, hspi_host_str);
+            initialized = do_intitialization(SPI3_HOST, spi3_initialized, spi3_initialized_count, spi3_host_str);
         }
-#else
-	// HSPI_HOST and VSPI_HOST deprecated for ESP32S2 and removed entirely for S3.
-        initialized = do_intitialization(host, spi_initialized, spi_initialized_count, spi_host_str);
-#endif // CONFIG_IDF_TARGET_ESP32
-
 
         return initialized;
     }
@@ -114,20 +106,15 @@ namespace smooth::core::io::spi
     {
         std::lock_guard<std::mutex> lock(guard);
 
-#ifdef CONFIG_IDF_TARGET_ESP32
-        if (spi_host == VSPI_HOST)
+        if (spi_host == SPI2_HOST)
         {
-            do_deinitialize(VSPI_HOST, vspi_initialized, vspi_initialized_count, vspi_host_str);
+            do_deinitialize(SPI2_HOST, spi2_initialized, spi2_initialized_count, spi2_host_str);
         }
 
-        if (spi_host == HSPI_HOST)
+        if (spi_host == SPI3_HOST)
         {
-            do_deinitialize(HSPI_HOST, hspi_initialized, hspi_initialized_count, hspi_host_str);
+            do_deinitialize(SPI3_HOST, spi3_initialized, spi3_initialized_count, spi3_host_str);
         }
-#else
-	// HSPI_HOST and VSPI_HOST deprecated for ESP32S2 and removed entirely for S3.
-        do_deinitialize(spi_host, spi_initialized, spi_initialized_count, spi_host_str);
-#endif // CONFIG_IDF_TARGET_ESP32
     }
 
     void Master::do_deinitialize(spi_host_device_t host,

--- a/lib/smooth/include/smooth/core/io/spi/Master.h
+++ b/lib/smooth/include/smooth/core/io/spi/Master.h
@@ -99,12 +99,10 @@ namespace smooth::core::io::spi
                                         uint8_t& initialized_count,
                                         const char* spi_host_str);
 
-            static bool hspi_initialized;
-            static bool vspi_initialized;
-            static bool spi_initialized;
-            static uint8_t hspi_initialized_count;
-            static uint8_t vspi_initialized_count;
-            static uint8_t spi_initialized_count;
+            static bool spi2_initialized;
+            static bool spi3_initialized;
+            static uint8_t spi2_initialized_count;
+            static uint8_t spi3_initialized_count;
             static std::mutex guard;
             static spi_bus_config_t bus_config;
             static spi_host_device_t spi_host;

--- a/lib/smooth/include/smooth/core/io/spi/Master.h
+++ b/lib/smooth/include/smooth/core/io/spi/Master.h
@@ -101,8 +101,10 @@ namespace smooth::core::io::spi
 
             static bool hspi_initialized;
             static bool vspi_initialized;
+            static bool spi_initialized;
             static uint8_t hspi_initialized_count;
             static uint8_t vspi_initialized_count;
+            static uint8_t spi_initialized_count;
             static std::mutex guard;
             static spi_bus_config_t bus_config;
             static spi_host_device_t spi_host;

--- a/test/spi_4_line_devices_test/spi_4_line_devices_test.cpp
+++ b/test/spi_4_line_devices_test/spi_4_line_devices_test.cpp
@@ -71,7 +71,11 @@ namespace spi_4_line_devices_test
     static const uint8_t FOUR_PARAMS = 0x04;
 
     App::App() : Application(APPLICATION_BASE_PRIO, seconds(3)),
+#ifdef CONFIG_IDF_TARGET_ESP32
             spi_host(VSPI_HOST)            // Use VSPI as host
+#else
+            spi_host(SPI3_HOST)            // Use SPI3 as host
+#endif // CONFIG_IDF_TARGET_ESP32
     {
     }
 

--- a/test/spi_4_line_devices_test/spi_4_line_devices_test.cpp
+++ b/test/spi_4_line_devices_test/spi_4_line_devices_test.cpp
@@ -71,11 +71,7 @@ namespace spi_4_line_devices_test
     static const uint8_t FOUR_PARAMS = 0x04;
 
     App::App() : Application(APPLICATION_BASE_PRIO, seconds(3)),
-#ifdef CONFIG_IDF_TARGET_ESP32
-            spi_host(VSPI_HOST)            // Use VSPI as host
-#else
             spi_host(SPI3_HOST)            // Use SPI3 as host
-#endif // CONFIG_IDF_TARGET_ESP32
     {
     }
 
@@ -83,7 +79,7 @@ namespace spi_4_line_devices_test
     {
         Application::init();
 
-        Master::initialize(spi_host,                   // host VSPI
+        Master::initialize(spi_host,                   // host SPI3
                            DMA_1,                      // use DMA
                            GPIO_NUM_23,                // mosi gpio pin
                            GPIO_NUM_19,                // miso gpio pin  (full duplex)


### PR DESCRIPTION
Per https://github.com/espressif/esp-idf/blob/master/components/hal/include/hal/spi_types.h, HSPI_HOST and VSPI_HOST don't exist on ESP32-S3, causing Smooth to fail while building. This change removes all references to HSPI_HOST and VSPI_HOST in favor of SPI2_HOST and SPI3_HOST. 